### PR TITLE
Complete vsprintk format coverage (#9)

### DIFF
--- a/src/kernel/console/vprintk.c
+++ b/src/kernel/console/vprintk.c
@@ -1,13 +1,144 @@
 #include <kernel/console.h>
+
+#include <ctype.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#define PADDING_NONE      0
-#define PADDING_SPACE     1
-#define PADDING_ZERO      2
-#define PADDING_PRECISION 3
-#define PADDING_INVALID   9
+typedef enum {
+  LEN_DEFAULT = 0,
+  LEN_LONG,
+  LEN_LONGLONG
+} length_modifier_t;
+
+static int append_chars(char* dest, int pos, char ch, int count) {
+  while(count-- > 0) {
+    dest[pos++] = ch;
+  }
+  return pos;
+}
+
+static int append_buffer(char* dest, int pos, const char* buf, int len) {
+  for(int i = 0; i < len; i++) {
+    dest[pos++] = buf[i];
+  }
+  return pos;
+}
+
+static int format_string(char* dest, int pos, const char* value, bool left_align, bool zero_pad,
+                         int width, bool precision_specified, int precision) {
+  if(value == NULL) {
+    value = "(null)";
+  }
+
+  int length = 0;
+  while(value[length] != '\0' && (!precision_specified || length < precision)) {
+    length++;
+  }
+
+  char pad_char = (zero_pad && !left_align) ? '0' : ' ';
+  int padding = width > length ? width - length : 0;
+
+  if(!left_align) {
+    pos = append_chars(dest, pos, pad_char, padding);
+  }
+
+  pos = append_buffer(dest, pos, value, length);
+
+  if(left_align) {
+    pos = append_chars(dest, pos, ' ', padding);
+  }
+
+  return pos;
+}
+
+static int format_char(char* dest, int pos, char value, bool left_align, bool zero_pad, int width) {
+  char pad_char = (zero_pad && !left_align) ? '0' : ' ';
+  int padding = width > 1 ? width - 1 : 0;
+
+  if(!left_align) {
+    pos = append_chars(dest, pos, pad_char, padding);
+  }
+
+  dest[pos++] = value;
+
+  if(left_align) {
+    pos = append_chars(dest, pos, ' ', padding);
+  }
+
+  return pos;
+}
+
+static int format_number(char* dest, int pos, uint64_t value, int base, bool uppercase,
+                         bool left_align, bool zero_pad, bool precision_specified, int precision,
+                         int width, const char* prefix, int prefix_len) {
+  char digits[65];
+  int digit_len = 0;
+
+  if(precision_specified && precision < 0) {
+    precision_specified = false;
+    precision = 0;
+  }
+
+  if(value == 0) {
+    if(!(precision_specified && precision == 0)) {
+      digits[digit_len++] = '0';
+    }
+  } else {
+    while(value != 0) {
+      uint64_t rem = value % (uint64_t)base;
+      if(rem < 10) {
+        digits[digit_len++] = (char)('0' + rem);
+      } else {
+        digits[digit_len++] = (char)((uppercase ? 'A' : 'a') + (rem - 10));
+      }
+      value /= (uint64_t)base;
+    }
+  }
+
+  int zero_digits = 0;
+
+  if(precision_specified) {
+    if(precision > digit_len) {
+      zero_digits = precision - digit_len;
+    }
+    zero_pad = false;
+  }
+
+  if(zero_pad && width > (prefix_len + digit_len)) {
+    zero_digits = width - (prefix_len + digit_len);
+  }
+
+  if(zero_digits < 0) {
+    zero_digits = 0;
+  }
+
+  int total_len = prefix_len + zero_digits + digit_len;
+  int space_pad = width > total_len ? width - total_len : 0;
+
+  if(!left_align) {
+    pos = append_chars(dest, pos, ' ', space_pad);
+  }
+
+  if(prefix_len > 0) {
+    pos = append_buffer(dest, pos, prefix, prefix_len);
+  }
+
+  pos = append_chars(dest, pos, '0', zero_digits);
+
+  for(int i = digit_len - 1; i >= 0; i--) {
+    dest[pos++] = digits[i];
+  }
+
+  if(left_align) {
+    pos = append_chars(dest, pos, ' ', space_pad);
+  }
+
+  return pos;
+}
 
 int vprintk(char *str, const char *format, ...) {
   va_list args;
@@ -19,248 +150,226 @@ int vprintk(char *str, const char *format, ...) {
 
 int vsprintk(char* str, const char* format, va_list args) {
   int result_len = 0;
-  
-  bool parsing = false;
-  int pad_type = PADDING_NONE;
-  int pad_len = 0;
 
-  for(int pos = 0; format[pos]; pos++) {
-    if(!parsing && format[pos] == '%') {
-      parsing = true;
+  for(int pos = 0; format[pos] != '\0';) {
+    if(format[pos] != '%') {
+      str[result_len++] = format[pos++];
       continue;
     }
 
-    if(parsing) {
+    pos++;
+
+    if(format[pos] == '%') {
+      str[result_len++] = '%';
+      pos++;
+      continue;
+    }
+
+    bool left_align = false;
+    bool alternate_form = false;
+    bool zero_pad = false;
+    int width = 0;
+    bool precision_specified = false;
+    int precision = 0;
+    length_modifier_t length = LEN_DEFAULT;
+
+    bool parsing_flags = true;
+    while(parsing_flags) {
       switch(format[pos]) {
-        case '0': {
-          if(pad_type == PADDING_NONE) {
-            pad_type = PADDING_ZERO;
-            break;
-          }
-        }
-        case '1':
-        case '2':
-        case '3':
-        case '4':
-        case '5':
-        case '6':
-        case '7':
-        case '8':
-        case '9': {
-          if(pad_type == PADDING_NONE) {
-            pad_type = PADDING_SPACE;
-          } else if(pad_type == PADDING_INVALID) {
-            parsing = false;
-            str[result_len++] = format[pos];
-            break;
-          }
+      case '-':
+        left_align = true;
+        pos++;
+        break;
+      case '#':
+        alternate_form = true;
+        pos++;
+        break;
+      case '0':
+        zero_pad = true;
+        pos++;
+        break;
+      default:
+        parsing_flags = false;
+        break;
+      }
+    }
 
-          pad_len = pad_len * 10 + (format[pos] - '0');
-          break;
-        }
-        case 'c': {
-          const int val = va_arg(args, int32_t);
-          if(pad_type == PADDING_NONE) {
-            pad_type = PADDING_INVALID;
-          }
-
-          if(pad_type == PADDING_SPACE || pad_type == PADDING_ZERO) {
-            for(int i = 0; i < pad_len - 1; i++) {
-              str[result_len++] = pad_type == PADDING_SPACE ? ' ' : '0';
-            }
-            pad_type = PADDING_NONE;
-            pad_len = 0;
-          }
-
-          str[result_len++] = val;
-          break;
-        }
-        case 'd': {
-          bool negative = false;
-          const int tmp_size = 32;
-          char tmp[tmp_size];
-          int val = va_arg(args, int32_t);
-          
-          if(pad_type == PADDING_ZERO && val < 0) {
-            negative = true;
-            val *= -1;
-          }
-
-          itoa(val, tmp, 10);
-
-          if(pad_type == PADDING_SPACE || pad_type == PADDING_ZERO) {
-            int padding = pad_len - strnlen(tmp, tmp_size) - (negative ? 1 : 0);
-
-            if(negative) {
-              str[result_len++] = '-';
-            }
-
-            for(int i = 0; i < padding; i++) {
-              str[result_len++] = pad_type == PADDING_SPACE ? ' ' : '0';
-            }
-            pad_type = PADDING_NONE;
-            pad_len = 0;
-          }
-
-          for(int i = 0; tmp[i]; i++) {
-            str[result_len++] = tmp[i];
-          }
-
-          break;
-        }
-        case 'l': {
-          switch(format[pos + 1]) {
-            case 'd': {
-              bool negative = false;
-              const int tmp_size = 32;
-              char tmp[tmp_size];
-              int64_t val = va_arg(args, int64_t);
-              
-              if(pad_type == PADDING_ZERO && val < 0) {
-                negative = true;
-                val *= -1;
-              }
-
-              ltoa(val, tmp, 10);
-
-              if(pad_type == PADDING_SPACE || pad_type == PADDING_ZERO) {
-                int padding = pad_len - strnlen(tmp, tmp_size) - (negative ? 1 : 0);
-
-                if(negative) {
-                  str[result_len++] = '-';
-                }
-
-                for(int i = 0; i < padding; i++) {
-                  str[result_len++] = pad_type == PADDING_SPACE ? ' ' : '0';
-                }
-                pad_type = PADDING_NONE;
-                pad_len = 0;
-              }
-
-              for(int i = 0; tmp[i]; i++) {
-                str[result_len++] = tmp[i];
-              }
-
-              break;
-            }
-            case 'x': {
-              pos++;
-              const int tmp_size = 64;
-              char tmp[tmp_size];
-              uint64_t val = va_arg(args, uint64_t);
-              lutoa(val, tmp, 16);
-
-              if(pad_type == PADDING_SPACE || pad_type == PADDING_ZERO) {
-                int padding = pad_len - strnlen(tmp, tmp_size);
-
-                for(int i = 0; i < padding; i++) {
-                  str[result_len++] = pad_type == PADDING_SPACE ? ' ' : '0';
-                }
-                pad_type = PADDING_NONE;
-                pad_len = 0;
-              }
-
-              for(int i = 0; tmp[i]; i++) {
-                str[result_len++] = tmp[i];
-              }
-
-              break;
-            }
-          }
-          break;
-        }
-        case 'p': {
-          void* val = va_arg(args, void*);
-          char* prefix = "0x";
-          char _tmp[256];
-          lutoa((uintptr_t)val, _tmp, 16);
-          while(*prefix) {
-            str[result_len++] = *prefix++;
-          };
-
-          char* tmp = _tmp;
-
-          while(*tmp) {
-            str[result_len++] = *tmp++;
-          }
-
-          break;
-        }
-        case 's': {
-          const char* val = (const char*)va_arg(args, char*);
-          uint32_t max_len = UINT32_MAX;
-          if(pad_type == PADDING_PRECISION) {
-            max_len = pad_len;
-          }
-          while(*val && max_len--) {
-            str[result_len++] = *val++;
-          }
-          break;
-        }
-        case 'u': {
-          const int tmp_size = 32;
-          char tmp[tmp_size];
-          const int val = va_arg(args, uint32_t);
-          utoa(val, tmp, 10);
-
-          if(pad_type == PADDING_SPACE || pad_type == PADDING_ZERO) {
-            int padding = pad_len - strnlen(tmp, tmp_size);
-
-            for(int i = 0; i < padding; i++) {
-              str[result_len++] = pad_type == PADDING_SPACE ? ' ' : '0';
-            }
-            pad_type = PADDING_NONE;
-            pad_len = 0;
-          }
-
-          for(int i = 0; tmp[i]; i++) {
-            str[result_len++] = tmp[i];
-          }
-
-          break;
-        }
-        case 'X': {
-          const int tmp_size = 64;
-          char tmp[tmp_size];
-          uint64_t val = va_arg(args, uint64_t);
-          lutoca(val, tmp, 16);
-
-          for(int i = 0; tmp[i]; i++) {
-            str[result_len++] = tmp[i];
-          }
-
-          break;
-        }
-        case 'x': {
-          const int tmp_size = 64;
-          char tmp[tmp_size];
-          uint32_t val = va_arg(args, uint32_t);
-          utoa(val, tmp, 16);
-
-          for(int i = 0; tmp[i]; i++) {
-            str[result_len++] = tmp[i];
-          }
-
-          break;
-        }
-        // case '.': {
-        //   if(pad_type == PADDING_NONE) {
-        //     pad_type = PADDING_PRECISION;
-        //     break;
-        //   }
-        //   str[result_len++] = '.';
-        //   break;
-        // }
-        default:
-          parsing = false;
-          str[result_len++] = format[pos];
-          break;
-        }
+    if(format[pos] == '*') {
+      width = va_arg(args, int);
+      if(width < 0) {
+        left_align = true;
+        width = -width;
+      }
+      pos++;
     } else {
-      parsing = false;
-      str[result_len++] = format[pos];
+      while(isdigit((unsigned char)format[pos])) {
+        width = width * 10 + (format[pos] - '0');
+        pos++;
+      }
+    }
+
+    if(format[pos] == '.') {
+      pos++;
+      precision_specified = true;
+      if(format[pos] == '*') {
+        precision = va_arg(args, int);
+        if(precision < 0) {
+          precision_specified = false;
+          precision = 0;
+        }
+        pos++;
+      } else {
+        while(isdigit((unsigned char)format[pos])) {
+          precision = precision * 10 + (format[pos] - '0');
+          pos++;
+        }
+      }
+    }
+
+    if(format[pos] == 'l') {
+      if(format[pos + 1] == 'l') {
+        length = LEN_LONGLONG;
+        pos += 2;
+      } else {
+        length = LEN_LONG;
+        pos++;
+      }
+    }
+
+    char specifier = format[pos];
+    if(specifier == '\0') {
+      break;
+    }
+    pos++;
+
+    if(left_align) {
+      zero_pad = false;
+    }
+
+    switch(specifier) {
+    case 'c': {
+      int value = va_arg(args, int);
+      result_len = format_char(str, result_len, (char)value, left_align, zero_pad, width);
+      break;
+    }
+    case 's': {
+      const char* value = va_arg(args, const char*);
+      result_len = format_string(str, result_len, value, left_align, zero_pad, width,
+                                 precision_specified, precision);
+      break;
+    }
+    case 'p': {
+      uintptr_t value = (uintptr_t)va_arg(args, void*);
+      char prefix_storage[3];
+      prefix_storage[0] = '0';
+      prefix_storage[1] = 'x';
+      prefix_storage[2] = '\0';
+      result_len = format_number(str, result_len, value, 16, false, left_align, zero_pad,
+                                 precision_specified, precision, width, prefix_storage, 2);
+      break;
+    }
+    case 'd':
+    case 'i': {
+      int64_t value;
+      if(length == LEN_LONGLONG) {
+        value = va_arg(args, long long);
+      } else if(length == LEN_LONG) {
+        value = va_arg(args, long);
+      } else {
+        value = va_arg(args, int);
+      }
+
+      bool negative = value < 0;
+      uint64_t magnitude;
+
+      if(negative) {
+        magnitude = (uint64_t)(-(value + 1));
+        magnitude += 1;
+      } else {
+        magnitude = (uint64_t)value;
+      }
+
+      char prefix_storage[2];
+      int prefix_len = 0;
+      if(negative) {
+        prefix_storage[prefix_len++] = '-';
+      }
+
+      result_len = format_number(str, result_len, magnitude, 10, false, left_align, zero_pad,
+                                 precision_specified, precision, width, prefix_storage,
+                                 prefix_len);
+      break;
+    }
+    case 'u': {
+      uint64_t value;
+      if(length == LEN_LONGLONG) {
+        value = va_arg(args, unsigned long long);
+      } else if(length == LEN_LONG) {
+        value = va_arg(args, unsigned long);
+      } else {
+        value = va_arg(args, unsigned int);
+      }
+
+      result_len = format_number(str, result_len, value, 10, false, left_align, zero_pad,
+                                 precision_specified, precision, width, NULL, 0);
+      break;
+    }
+    case 'x':
+    case 'X': {
+      bool uppercase = specifier == 'X';
+      uint64_t value;
+      if(length == LEN_LONGLONG) {
+        value = va_arg(args, unsigned long long);
+      } else if(length == LEN_LONG) {
+        value = va_arg(args, unsigned long);
+      } else {
+        value = va_arg(args, unsigned int);
+      }
+
+      char prefix_storage[3];
+      int prefix_len = 0;
+      if(alternate_form && value != 0) {
+        prefix_storage[prefix_len++] = '0';
+        prefix_storage[prefix_len++] = uppercase ? 'X' : 'x';
+      }
+
+      result_len = format_number(str, result_len, value, 16, uppercase, left_align, zero_pad,
+                                 precision_specified, precision, width,
+                                 prefix_len ? prefix_storage : NULL, prefix_len);
+      break;
+    }
+    case 'o': {
+      uint64_t value;
+      if(length == LEN_LONGLONG) {
+        value = va_arg(args, unsigned long long);
+      } else if(length == LEN_LONG) {
+        value = va_arg(args, unsigned long);
+      } else {
+        value = va_arg(args, unsigned int);
+      }
+
+      char prefix_storage[2];
+      int prefix_len = 0;
+      if(alternate_form && value != 0) {
+        prefix_storage[prefix_len++] = '0';
+      }
+
+      result_len = format_number(str, result_len, value, 8, false, left_align, zero_pad,
+                                 precision_specified, precision, width,
+                                 prefix_len ? prefix_storage : NULL, prefix_len);
+      break;
+    }
+    case '%': {
+      result_len = format_char(str, result_len, '%', left_align, zero_pad, width > 1 ? width : 1);
+      break;
+    }
+    default: {
+      str[result_len++] = specifier;
+      break;
+    }
     }
   }
+
   str[result_len] = '\0';
 
   return result_len;

--- a/test/test_vsprintk.c
+++ b/test/test_vsprintk.c
@@ -177,6 +177,12 @@ void test_vprintk_WHEN_percent_percent_SHOULD_return_percent_sign() {
   TEST_ASSERT_EQUAL_STRING("100%", buffer);
 }
 
+void test_vprintk_WHEN_percent_with_width_SHOULD_apply_padding() {
+  char buffer[256];
+  vprintk(buffer, "%05%", 0);
+  TEST_ASSERT_EQUAL_STRING("0000%", buffer);
+}
+
 void test_vprintk_WHEN_percent_minus_SHOULD_left_align() {
   char buffer[256];
   vprintk(buffer, "%-5d", 123);
@@ -197,8 +203,8 @@ void test_vprintk_WHEN_multiple_specifiers_SHOULD_format_correctly() {
 
 void test_vprintk_WHEN_width_and_precision_SHOULD_format_correctly() {
   char buffer[256];
-  vprintk(buffer, "%8.3d", 12345);
-  TEST_ASSERT_EQUAL_STRING("    123", buffer);
+  vprintk(buffer, "%8.3d", 123);
+  TEST_ASSERT_EQUAL_STRING("     123", buffer);
 }
 
 void test_vprintk_WHEN_large_number_SHOULD_print_correctly() {
@@ -223,6 +229,12 @@ void test_vprintk_WHEN_long_long_SHOULD_print_correctly() {
   char buffer[256];
   vprintk(buffer, "%lld", 9223372036854775807LL);  // LLONG_MAX
   TEST_ASSERT_EQUAL_STRING("9223372036854775807", buffer);
+}
+
+void test_vprintk_WHEN_unsigned_long_long_SHOULD_print_correctly() {
+  char buffer[256];
+  vprintk(buffer, "%llu", 18446744073709551615ULL);
+  TEST_ASSERT_EQUAL_STRING("18446744073709551615", buffer);
 }
 
 void test_vprintk_WHEN_multiple_args_SHOULD_print_correctly() {
@@ -267,6 +279,12 @@ void test_vprintk_WHEN_hash_with_hex_SHOULD_add_prefix() {
   TEST_ASSERT_EQUAL_STRING("0xff", buffer);
 }
 
+void test_vprintk_WHEN_hash_with_uppercase_hex_SHOULD_add_prefix() {
+  char buffer[256];
+  vprintk(buffer, "%#X", 255);
+  TEST_ASSERT_EQUAL_STRING("0XFF", buffer);
+}
+
 void test_vprintk_WHEN_percent_ld_SHOULD_print_long_decimal() {
     char buffer[256];
     vprintk(buffer, "%ld", 2147483648L);
@@ -297,7 +315,7 @@ void test_vprintk_WHEN_percent_lx_SHOULD_print_long_hex() {
 void test_vprintk_WHEN_long_with_padding_SHOULD_format_correctly() {
     char buffer[256];
     vprintk(buffer, "%10ld", 123456L);
-    TEST_ASSERT_EQUAL_STRING("   123456", buffer);
+    TEST_ASSERT_EQUAL_STRING("    123456", buffer);
 
     vprintk(buffer, "%010lu", 123456UL);
     TEST_ASSERT_EQUAL_STRING("0000123456", buffer);
@@ -326,6 +344,7 @@ int main() {
   RUN_TEST(test_vprintk_WHEN_percent_s_SHOULD_return_string);
   RUN_TEST(test_vprintk_WHEN_percent_p_SHOULD_return_pointer_address);
   RUN_TEST(test_vprintk_WHEN_percent_percent_SHOULD_return_percent_sign);
+  RUN_TEST(test_vprintk_WHEN_percent_with_width_SHOULD_apply_padding);
   RUN_TEST(test_vprintk_WHEN_percent_minus_SHOULD_left_align);
   RUN_TEST(test_vprintk_WHEN_precision_SHOULD_limit_string_length);
   RUN_TEST(test_vprintk_WHEN_multiple_specifiers_SHOULD_format_correctly);
@@ -341,11 +360,13 @@ int main() {
   RUN_TEST(test_vprintk_WHEN_asterisk_for_width_SHOULD_use_argument);
   RUN_TEST(test_vprintk_WHEN_asterisk_for_precision_SHOULD_use_argument);
   RUN_TEST(test_vprintk_WHEN_hash_with_hex_SHOULD_add_prefix);
+  RUN_TEST(test_vprintk_WHEN_hash_with_uppercase_hex_SHOULD_add_prefix);
 
   RUN_TEST(test_vprintk_WHEN_percent_ld_SHOULD_print_long_decimal);
   RUN_TEST(test_vprintk_WHEN_percent_lu_SHOULD_print_unsigned_long);
   RUN_TEST(test_vprintk_WHEN_percent_lx_SHOULD_print_long_hex);
   RUN_TEST(test_vprintk_WHEN_long_with_padding_SHOULD_format_correctly);
+  RUN_TEST(test_vprintk_WHEN_unsigned_long_long_SHOULD_print_correctly);
 
   return UNITY_END();
 }

--- a/test/test_vsprintk.c
+++ b/test/test_vsprintk.c
@@ -1,5 +1,6 @@
 #include <kernel/console.h>
 
+#include <stddef.h>
 #include <string.h>
 #include <unity.h>
 
@@ -164,6 +165,12 @@ void test_vprintk_WHEN_percent_s_SHOULD_return_string() {
   TEST_ASSERT_EQUAL_STRING("Hello, World!", buffer);
 }
 
+void test_vprintk_WHEN_percent_s_receives_null_SHOULD_print_null_literal() {
+  char buffer[256];
+  vprintk(buffer, "%s", NULL);
+  TEST_ASSERT_EQUAL_STRING("(null)", buffer);
+}
+
 void test_vprintk_WHEN_percent_p_SHOULD_return_pointer_address() {
   char buffer[256];
   int *x = (int*)0x1000;
@@ -181,6 +188,18 @@ void test_vprintk_WHEN_percent_with_width_SHOULD_apply_padding() {
   char buffer[256];
   vprintk(buffer, "%05%", 0);
   TEST_ASSERT_EQUAL_STRING("0000%", buffer);
+}
+
+void test_vprintk_WHEN_precision_zero_and_value_zero_SHOULD_render_empty() {
+  char buffer[256];
+  vprintk(buffer, "%.0d", 0);
+  TEST_ASSERT_EQUAL_STRING("", buffer);
+}
+
+void test_vprintk_WHEN_width_and_zero_precision_SHOULD_render_spaces() {
+  char buffer[256];
+  vprintk(buffer, "%5.0d", 0);
+  TEST_ASSERT_EQUAL_STRING("     ", buffer);
 }
 
 void test_vprintk_WHEN_percent_minus_SHOULD_left_align() {
@@ -267,6 +286,12 @@ void test_vprintk_WHEN_asterisk_for_width_SHOULD_use_argument() {
   TEST_ASSERT_EQUAL_STRING("  123", buffer);
 }
 
+void test_vprintk_WHEN_negative_width_via_asterisk_SHOULD_left_align() {
+  char buffer[256];
+  vprintk(buffer, "%*d", -5, 123);
+  TEST_ASSERT_EQUAL_STRING("123  ", buffer);
+}
+
 void test_vprintk_WHEN_asterisk_for_precision_SHOULD_use_argument() {
   char buffer[256];
   vprintk(buffer, "%.*s", 3, "hello");
@@ -283,6 +308,21 @@ void test_vprintk_WHEN_hash_with_uppercase_hex_SHOULD_add_prefix() {
   char buffer[256];
   vprintk(buffer, "%#X", 255);
   TEST_ASSERT_EQUAL_STRING("0XFF", buffer);
+}
+
+void test_vprintk_WHEN_hash_with_octal_SHOULD_add_leading_zero() {
+  char buffer[256];
+  vprintk(buffer, "%#o", 064);
+  TEST_ASSERT_EQUAL_STRING("064", buffer);
+
+  vprintk(buffer, "%#o", 0);
+  TEST_ASSERT_EQUAL_STRING("0", buffer);
+}
+
+void test_vprintk_WHEN_pointer_with_width_SHOULD_pad_left() {
+  char buffer[256];
+  vprintk(buffer, "%20p", (void*)0x1234);
+  TEST_ASSERT_EQUAL_STRING("              0x1234", buffer);
 }
 
 void test_vprintk_WHEN_percent_ld_SHOULD_print_long_decimal() {
@@ -342,9 +382,12 @@ int main() {
   RUN_TEST(test_vprintk_WHEN_percent_x_SHOULD_return_lowercase_hex);
   RUN_TEST(test_vprintk_WHEN_percent_X_SHOULD_return_uppercase_hex);
   RUN_TEST(test_vprintk_WHEN_percent_s_SHOULD_return_string);
+  RUN_TEST(test_vprintk_WHEN_percent_s_receives_null_SHOULD_print_null_literal);
   RUN_TEST(test_vprintk_WHEN_percent_p_SHOULD_return_pointer_address);
   RUN_TEST(test_vprintk_WHEN_percent_percent_SHOULD_return_percent_sign);
   RUN_TEST(test_vprintk_WHEN_percent_with_width_SHOULD_apply_padding);
+  RUN_TEST(test_vprintk_WHEN_precision_zero_and_value_zero_SHOULD_render_empty);
+  RUN_TEST(test_vprintk_WHEN_width_and_zero_precision_SHOULD_render_spaces);
   RUN_TEST(test_vprintk_WHEN_percent_minus_SHOULD_left_align);
   RUN_TEST(test_vprintk_WHEN_precision_SHOULD_limit_string_length);
   RUN_TEST(test_vprintk_WHEN_multiple_specifiers_SHOULD_format_correctly);
@@ -358,9 +401,12 @@ int main() {
   RUN_TEST(test_vprintk_WHEN_precision_with_int_SHOULD_pad_correctly);
   RUN_TEST(test_vprintk_WHEN_width_and_precision_with_string_SHOULD_format_correctly);
   RUN_TEST(test_vprintk_WHEN_asterisk_for_width_SHOULD_use_argument);
+  RUN_TEST(test_vprintk_WHEN_negative_width_via_asterisk_SHOULD_left_align);
   RUN_TEST(test_vprintk_WHEN_asterisk_for_precision_SHOULD_use_argument);
   RUN_TEST(test_vprintk_WHEN_hash_with_hex_SHOULD_add_prefix);
   RUN_TEST(test_vprintk_WHEN_hash_with_uppercase_hex_SHOULD_add_prefix);
+  RUN_TEST(test_vprintk_WHEN_hash_with_octal_SHOULD_add_leading_zero);
+  RUN_TEST(test_vprintk_WHEN_pointer_with_width_SHOULD_pad_left);
 
   RUN_TEST(test_vprintk_WHEN_percent_ld_SHOULD_print_long_decimal);
   RUN_TEST(test_vprintk_WHEN_percent_lu_SHOULD_print_unsigned_long);


### PR DESCRIPTION
  ## Summary
  - rewrite vsprintk parsing to handle flags, dynamic width/precision, and l/ll modifiers
  - share helpers for padding/prefixing so %p, %#x/%#X, %05% etc. render correctly
  - add Unity tests for null strings, zero-precision numbers, negative * widths, and octal/pointer alt forms

  ## Testing
  - gcc -Iinclude test/unity.c test/stubs.c test/test_vsprintk.c \
        src/kernel/console/vprintk.c src/libc/itoa.c -o test_vsprintk
  - ./test_vsprintk