### PR TITLE
Complete ANSI console support (#8)

### DIFF
--- a/include/kernel/ansi.h
+++ b/include/kernel/ansi.h
@@ -1,0 +1,24 @@
+#ifndef MENIOS_INCLUDE_KERNEL_ANSI_H
+#define MENIOS_INCLUDE_KERNEL_ANSI_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define ANSI_ATTR_BOLD       0x01
+#define ANSI_ATTR_DIM        0x02
+#define ANSI_ATTR_UNDERLINE  0x04
+#define ANSI_ATTR_REVERSE    0x08
+
+typedef struct ansi_style_t {
+  uint8_t fg;
+  uint8_t bg;
+  uint8_t attrs;
+} ansi_style_t;
+
+void ansi_style_reset(ansi_style_t* style);
+void ansi_style_apply_sgr(ansi_style_t* style, const int* params, size_t param_count);
+void ansi_style_effective_colors(const ansi_style_t* style, uint32_t* fg, uint32_t* bg);
+uint32_t ansi_palette_color(uint8_t index);
+uint32_t ansi_dim_color(uint32_t rgb);
+
+#endif

--- a/include/kernel/framebuffer.h
+++ b/include/kernel/framebuffer.h
@@ -3,16 +3,23 @@
 
 #include <types.h>
 
-#define FB_BLACK       0x0
-#define FB_BLUE        0x0000ff
-#define FB_DARK_BLUE   0x00007f
-#define FB_DARK_GREEN  0x007f00
-#define FB_DARK_RED    0x7f0000
-#define FB_GREEN       0x00ff00
-#define FB_LIGHT_WHITE 0xffffff
-#define FB_RED         0xff0000
-#define FB_WHITE       0x7f7f7f
-#define FB_ORANGE      0xff7f00
+#define FB_BLACK        0x000000
+#define FB_DARK_RED     0x7f0000
+#define FB_DARK_GREEN   0x007f00
+#define FB_DARK_YELLOW  0x7f7f00
+#define FB_DARK_BLUE    0x00007f
+#define FB_DARK_MAGENTA 0x7f007f
+#define FB_DARK_CYAN    0x007f7f
+#define FB_WHITE        0xc0c0c0
+#define FB_LIGHT_BLACK  0x7f7f7f
+#define FB_RED          0xff0000
+#define FB_GREEN        0x00ff00
+#define FB_YELLOW       0xffff00
+#define FB_BLUE         0x0000ff
+#define FB_MAGENTA      0xff00ff
+#define FB_CYAN         0x00ffff
+#define FB_LIGHT_WHITE  0xffffff
+#define FB_ORANGE       0xff7f00
 
 typedef struct limine_video_mode** limine_video_mode_list_t;
 typedef struct limine_video_mode* limine_video_mode_t;

--- a/src/kernel/console/ansi.c
+++ b/src/kernel/console/ansi.c
@@ -1,0 +1,155 @@
+#include <kernel/ansi.h>
+
+#include <stdint.h>
+
+static const uint32_t ansi_palette[16] = {
+  0x000000, // black
+  0x800000, // red
+  0x008000, // green
+  0x808000, // yellow
+  0x000080, // blue
+  0x800080, // magenta
+  0x008080, // cyan
+  0xc0c0c0, // white
+  0x808080, // bright black (grey)
+  0xff0000, // bright red
+  0x00ff00, // bright green
+  0xffff00, // bright yellow
+  0x0000ff, // bright blue
+  0xff00ff, // bright magenta
+  0x00ffff, // bright cyan
+  0xffffff  // bright white
+};
+
+void ansi_style_reset(ansi_style_t* style) {
+  if(style == NULL) {
+    return;
+  }
+
+  style->fg = 7; // white
+  style->bg = 0; // black
+  style->attrs = 0;
+}
+
+static uint32_t scale_component(uint32_t value, uint32_t numerator, uint32_t denominator) {
+  return (value * numerator) / denominator;
+}
+
+uint32_t ansi_dim_color(uint32_t rgb) {
+  uint32_t r = (rgb >> 16) & 0xff;
+  uint32_t g = (rgb >> 8) & 0xff;
+  uint32_t b = rgb & 0xff;
+
+  r = scale_component(r, 1, 2);
+  g = scale_component(g, 1, 2);
+  b = scale_component(b, 1, 2);
+
+  return (r << 16) | (g << 8) | b;
+}
+
+uint32_t ansi_palette_color(uint8_t index) {
+  return ansi_palette[index % 16];
+}
+
+void ansi_style_effective_colors(const ansi_style_t* style, uint32_t* fg, uint32_t* bg) {
+  if(style == NULL) {
+    return;
+  }
+
+  uint8_t fg_index = style->fg % 16;
+  uint8_t bg_index = style->bg % 16;
+
+  uint32_t fg_color = ansi_palette_color(fg_index);
+  uint32_t bg_color = ansi_palette_color(bg_index);
+
+  if(style->attrs & ANSI_ATTR_BOLD) {
+    if(fg_index < 8) {
+      fg_color = ansi_palette_color(fg_index + 8);
+    }
+  }
+
+  if(style->attrs & ANSI_ATTR_DIM) {
+    fg_color = ansi_dim_color(fg_color);
+  }
+
+  if(style->attrs & ANSI_ATTR_REVERSE) {
+    uint32_t tmp = fg_color;
+    fg_color = bg_color;
+    bg_color = tmp;
+  }
+
+  if(fg != NULL) {
+    *fg = fg_color;
+  }
+
+  if(bg != NULL) {
+    *bg = bg_color;
+  }
+}
+
+static void handle_reset(ansi_style_t* style) {
+  ansi_style_reset(style);
+}
+
+static void handle_color(ansi_style_t* style, int param) {
+  if(param >= 30 && param <= 37) {
+    style->fg = (uint8_t)(param - 30);
+  } else if(param == 39) {
+    style->fg = 7;
+  } else if(param >= 40 && param <= 47) {
+    style->bg = (uint8_t)(param - 40);
+  } else if(param == 49) {
+    style->bg = 0;
+  } else if(param >= 90 && param <= 97) {
+    style->fg = (uint8_t)((param - 90) + 8);
+  } else if(param >= 100 && param <= 107) {
+    style->bg = (uint8_t)((param - 100) + 8);
+  }
+}
+
+void ansi_style_apply_sgr(ansi_style_t* style, const int* params, size_t param_count) {
+  if(style == NULL) {
+    return;
+  }
+
+  if(param_count == 0) {
+    handle_reset(style);
+    return;
+  }
+
+  for(size_t i = 0; i < param_count; i++) {
+    int param = params[i];
+
+    switch(param) {
+      case 0:
+        handle_reset(style);
+        break;
+      case 1:
+        style->attrs |= ANSI_ATTR_BOLD;
+        style->attrs &= (uint8_t)~ANSI_ATTR_DIM;
+        break;
+      case 2:
+        style->attrs |= ANSI_ATTR_DIM;
+        style->attrs &= (uint8_t)~ANSI_ATTR_BOLD;
+        break;
+      case 4:
+        style->attrs |= ANSI_ATTR_UNDERLINE;
+        break;
+      case 7:
+        style->attrs |= ANSI_ATTR_REVERSE;
+        break;
+      case 22:
+        style->attrs &= (uint8_t)~(ANSI_ATTR_BOLD | ANSI_ATTR_DIM);
+        break;
+      case 24:
+        style->attrs &= (uint8_t)~ANSI_ATTR_UNDERLINE;
+        break;
+      case 27:
+        style->attrs &= (uint8_t)~ANSI_ATTR_REVERSE;
+        break;
+      default:
+        handle_color(style, param);
+        break;
+    }
+  }
+}

--- a/src/kernel/framebuffer.c
+++ b/src/kernel/framebuffer.c
@@ -1,17 +1,38 @@
 #include <stddef.h>
+
 #include <boot/limine.h>
+
+#include <kernel/ansi.h>
 #include <kernel/console.h>
 #include <kernel/fonts.h>
 #include <kernel/framebuffer.h>
 #include <kernel/kernel.h>
 #include <kernel/serial.h>
-#include <stdlib.h>
+
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <types.h>
 
-#define ANSI_NONE        0;
-#define ANSI_SET_COLOR   1;
+#define FB_MARGIN_X 10
+#define FB_MARGIN_Y 10
+#define MAX_COLS 200
+#define MAX_VISIBLE_ROWS 80
+#define SCROLLBACK_LINES 1024
+#define CSI_MAX_PARAMS 8
+
+typedef enum {
+  ANSI_STATE_NORMAL = 0,
+  ANSI_STATE_ESCAPE,
+  ANSI_STATE_CSI
+} ansi_parser_state_t;
+
+typedef struct {
+  char ch;
+  ansi_style_t style;
+} console_cell_t;
 
 static volatile struct limine_framebuffer_request framebuffer_request = {
   .id = LIMINE_FRAMEBUFFER_REQUEST,
@@ -19,23 +40,34 @@ static volatile struct limine_framebuffer_request framebuffer_request = {
 };
 
 static bool active;
-static bool ansi_code;
-static int ansi_command;
-static int ansi_color;
-static int char_line_height;
-static int char_line_width;
-static int current_col;
-static int current_row;
-static int viewpoint_x;
-static int viewpoint_y;
-static uint32_t color_bg = FB_BLACK;
-static uint32_t color_fg = FB_LIGHT_WHITE;
-
+static uint32_t char_line_height;
+static uint32_t char_line_width;
+static uint32_t visible_cols;
+static uint32_t visible_rows;
+static uint64_t cursor_row;
+static uint32_t cursor_col;
+static uint64_t viewport_row;
+static uint64_t total_rows;
+static ansi_style_t default_style;
+static ansi_style_t current_style;
+static ansi_style_t saved_style;
+static bool has_saved_cursor;
+static uint64_t saved_cursor_row;
+static uint32_t saved_cursor_col;
 static struct limine_framebuffer *framebuffer;
-
 static FILE* fb_d;
-#define ROWS 48
-#define COLS 157
+
+static console_cell_t console_buffer[SCROLLBACK_LINES][MAX_COLS];
+static uint64_t row_versions[SCROLLBACK_LINES];
+
+static ansi_parser_state_t ansi_state;
+static int csi_params[CSI_MAX_PARAMS];
+static size_t csi_param_count;
+static bool csi_param_active;
+static bool csi_private_sequence;
+
+static void clear_line_segment(uint64_t row, uint32_t start_col, uint32_t end_col, const ansi_style_t* style);
+static void render_viewport(void);
 
 inline uint64_t fb_count() {
   return framebuffer_request.response->framebuffer_count;
@@ -49,37 +81,221 @@ inline uint64_t fb_mode_count() {
   return framebuffer->mode_count;
 }
 
+static inline uint32_t row_index(uint64_t row) {
+  return (uint32_t)(row % SCROLLBACK_LINES);
+}
+
+static inline console_cell_t* cell_at(uint64_t row, uint32_t col) {
+  return &console_buffer[row_index(row)][col];
+}
+
+static void ensure_row(uint64_t row, const ansi_style_t* style) {
+  uint32_t idx = row_index(row);
+  if(row_versions[idx] == row) {
+    return;
+  }
+
+  row_versions[idx] = row;
+
+  ansi_style_t fill_style = style ? *style : default_style;
+  for(uint32_t col = 0; col < visible_cols; col++) {
+    console_buffer[idx][col].ch = ' ';
+    console_buffer[idx][col].style = fill_style;
+  }
+}
+
+static void copy_row(uint64_t dst_row, uint64_t src_row) {
+  ensure_row(src_row, &default_style);
+  ensure_row(dst_row, &default_style);
+
+  uint32_t dst_idx = row_index(dst_row);
+  uint32_t src_idx = row_index(src_row);
+
+  memcpy(console_buffer[dst_idx], console_buffer[src_idx], visible_cols * sizeof(console_cell_t));
+  row_versions[dst_idx] = dst_row;
+}
+
+static void scroll_region_up(uint32_t lines) {
+  if(lines == 0) {
+    return;
+  }
+
+  if(lines >= visible_rows) {
+    for(uint32_t offset = 0; offset < visible_rows; offset++) {
+      uint64_t row = viewport_row + offset;
+      ensure_row(row, &default_style);
+      clear_line_segment(row, 0, visible_cols - 1, &default_style);
+    }
+    render_viewport();
+    return;
+  }
+
+  uint64_t base = viewport_row;
+  for(uint32_t offset = 0; offset < visible_rows - lines; offset++) {
+    copy_row(base + offset, base + offset + lines);
+  }
+
+  for(uint32_t offset = visible_rows - lines; offset < visible_rows; offset++) {
+    uint64_t row = base + offset;
+    ensure_row(row, &default_style);
+    clear_line_segment(row, 0, visible_cols - 1, &default_style);
+  }
+
+  render_viewport();
+}
+
+static void scroll_region_down(uint32_t lines) {
+  if(lines == 0) {
+    return;
+  }
+
+  if(lines >= visible_rows) {
+    for(uint32_t offset = 0; offset < visible_rows; offset++) {
+      uint64_t row = viewport_row + offset;
+      ensure_row(row, &default_style);
+      clear_line_segment(row, 0, visible_cols - 1, &default_style);
+    }
+    render_viewport();
+    return;
+  }
+
+  uint64_t base = viewport_row;
+  for(int32_t offset = (int32_t)visible_rows - 1; offset >= (int32_t)lines; offset--) {
+    copy_row(base + (uint32_t)offset, base + (uint32_t)(offset - lines));
+  }
+
+  for(uint32_t offset = 0; offset < lines && offset < visible_rows; offset++) {
+    uint64_t row = base + offset;
+    ensure_row(row, &default_style);
+    clear_line_segment(row, 0, visible_cols - 1, &default_style);
+  }
+
+  render_viewport();
+}
+
 void gotoxy(uint32_t x, uint32_t y) {
-  current_col = x;
-  current_row = y;
+  cursor_col = x < visible_cols ? x : (visible_cols - 1);
+  cursor_row = viewport_row + (y < visible_rows ? y : (visible_rows - 1));
 }
 
 void get_cursor_pos(screen_pos_t* pos) {
-  pos->x = current_col;
-  pos->y = current_row;
+  if(!pos) {
+    return;
+  }
+
+  pos->x = (uint8_t)cursor_col;
+  pos->y = (uint8_t)(cursor_row - viewport_row);
+}
+
+static void draw_cell(uint64_t row, uint32_t col) {
+  if(row < viewport_row || (row - viewport_row) >= visible_rows) {
+    return;
+  }
+
+  console_cell_t* cell = cell_at(row, col);
+  uint32_t fg_color;
+  uint32_t bg_color;
+
+  ansi_style_effective_colors(&cell->style, &fg_color, &bg_color);
+
+  uint32_t screen_row = (uint32_t)(row - viewport_row);
+  int x = FB_MARGIN_X + (int)(col * char_line_width);
+  int y = FB_MARGIN_Y + (int)(screen_row * char_line_height);
+
+  glypht_t glyph = font_glyph(cell->ch ? cell->ch : ' ');
+
+  for(uint32_t gx = 0; gx < char_line_width; gx++) {
+    for(uint32_t gy = 0; gy < char_line_height; gy++) {
+      fb_putpixel((uint32_t)(x + gx), (uint32_t)(y + gy), bg_color);
+    }
+  }
+
+  for(uint32_t gx = 0; gx < 8; gx++) {
+    for(uint32_t gy = 0; gy < 16 && gy < char_line_height; gy++) {
+      if((glyph.points[gy] >> (7 - gx)) & 0x01) {
+        fb_putpixel((uint32_t)(x + gx), (uint32_t)(y + gy), fg_color);
+      }
+    }
+  }
+
+  if(cell->style.attrs & ANSI_ATTR_UNDERLINE) {
+    uint32_t underline_y = (uint32_t)(y + char_line_height - 1);
+    for(uint32_t gx = 0; gx < char_line_width; gx++) {
+      fb_putpixel((uint32_t)(x + gx), underline_y, fg_color);
+    }
+  }
+}
+
+static void draw_row(uint64_t row) {
+  if(row < viewport_row || (row - viewport_row) >= visible_rows) {
+    return;
+  }
+
+  for(uint32_t col = 0; col < visible_cols; col++) {
+    draw_cell(row, col);
+  }
+}
+
+static void render_viewport(void) {
+  for(uint32_t visible = 0; visible < visible_rows; visible++) {
+    uint64_t row = viewport_row + visible;
+    ensure_row(row, &default_style);
+    draw_row(row);
+  }
 }
 
 void fb_init() {
-  // Ensure we got a framebuffer.
   if(framebuffer_request.response == NULL || framebuffer_request.response->framebuffer_count < 1) {
-    serial_error("Panic in framebuffer.c:46");
+    serial_error("Panic in framebuffer.c:fb_init");
     halt();
   }
 
-  // Fetch the first framebuffer.
   framebuffer = framebuffer_request.response->framebuffers[0];
-
   active = true;
 
-  viewpoint_x = framebuffer->width - 20;
-  viewpoint_y = framebuffer->height - 20;
-  current_row = 0;
-  current_col = 0;
-  char_line_width = 8; //viewpoint_x / COLS;
-  char_line_height = 16; // viewpoint_y / ROWS;
+  char_line_width = 8;
+  char_line_height = 16;
+
+  visible_cols = (framebuffer->width > (FB_MARGIN_X * 2))
+                   ? (uint32_t)((framebuffer->width - (FB_MARGIN_X * 2)) / char_line_width)
+                   : 0;
+  if(visible_cols > MAX_COLS) {
+    visible_cols = MAX_COLS;
+  }
+
+  visible_rows = (framebuffer->height > (FB_MARGIN_Y * 2))
+                   ? (uint32_t)((framebuffer->height - (FB_MARGIN_Y * 2)) / char_line_height)
+                   : 0;
+  if(visible_rows > MAX_VISIBLE_ROWS) {
+    visible_rows = MAX_VISIBLE_ROWS;
+  }
+
+  if(visible_cols == 0 || visible_rows == 0) {
+    serial_error("framebuffer: invalid console geometry");
+    halt();
+  }
+
+  for(size_t i = 0; i < SCROLLBACK_LINES; i++) {
+    row_versions[i] = UINT64_MAX;
+  }
+
+  ansi_style_reset(&current_style);
+  default_style = current_style;
+  saved_style = current_style;
+  has_saved_cursor = false;
+
+  cursor_row = 0;
+  cursor_col = 0;
+  viewport_row = 0;
+  total_rows = visible_rows;
+
+  for(uint32_t row = 0; row < visible_rows; row++) {
+    ensure_row(row, &default_style);
+  }
+
+  render_viewport();
 
   fb_d = freopen("/dev/fb/0", "w", stdout);
-
   if(fb_d == NULL) {
     serial_error("freopen(/dev/fb/0) -> NULL");
     halt();
@@ -90,129 +306,412 @@ inline bool fb_active() {
   return active;
 }
 
-void fb_draw() {
-  // Note: we assume the framebuffer model is RGB with 32-bit pixels.
-  for(size_t i = 0; i < 100; i++) {
-    uint32_t *fb_ptr = framebuffer->address;
-    fb_ptr[i * (framebuffer->pitch / 4) + i] = 0xffffff;
-  }
-}
-
 void fb_putpixel(uint32_t x, uint32_t y, uint32_t rgb) {
   uint32_t *fb_ptr = framebuffer->address;
   fb_ptr[y * (framebuffer->pitch / 4) + x] = rgb;
 }
 
-// FIXME: use doublebuffer to draw the line
-// TODO: need to implement malloc for this
-void fb_drawline(uint32_t left, uint32_t right, uint32_t top, uint32_t bottom, uint32_t rgb) {
-  for(uint32_t x = left; x < right; x++) {
-    fb_putpixel(x, top, rgb);
+static uint64_t max_viewport_row(void) {
+  if(total_rows <= visible_rows) {
+    return 0;
+  }
+  return total_rows - visible_rows;
+}
+
+static void sync_viewport_to_cursor(void) {
+  uint64_t max_view = max_viewport_row();
+  if(cursor_row >= viewport_row + visible_rows) {
+    viewport_row = cursor_row >= max_view ? max_view : cursor_row - visible_rows + 1;
+    render_viewport();
+  } else if(cursor_row < viewport_row) {
+    viewport_row = cursor_row;
+    render_viewport();
   }
 }
 
-void fb_scroll_up(int lines) {
-  uint32_t *fb_ptr = framebuffer->address;
-  uint32_t *fb_ptr2 = framebuffer->address;
-
-  for(int y = 0; y < (framebuffer->height - (lines * char_line_height)); y++) {
-    for(int x = 0; x < (framebuffer->width - 20); x++) {
-      fb_ptr[y * (framebuffer->pitch / 4) + x] = fb_ptr2[(y + (lines * char_line_height)) * (framebuffer->pitch / 4) + x];
-    }
+static void clear_range(uint64_t start_row, uint32_t start_col, uint64_t end_row, uint32_t end_col, const ansi_style_t* style) {
+  if(end_row < start_row) {
+    return;
   }
 
-  for(int y = (framebuffer->height - (lines * char_line_height)); y < framebuffer->height; y++) {
-    for(int x = 0; x < (framebuffer->width - 20); x++) {
-      fb_putpixel(x, y, color_bg);
+  for(uint64_t row = start_row; row <= end_row; row++) {
+    ensure_row(row, style);
+    uint32_t begin_col = (row == start_row) ? start_col : 0;
+    uint32_t finish_col = (row == end_row) ? end_col : (visible_cols - 1);
+    console_cell_t* cells = cell_at(row, 0);
+    for(uint32_t col = begin_col; col <= finish_col && col < visible_cols; col++) {
+      cells[col].ch = ' ';
+      cells[col].style = style ? *style : default_style;
     }
+    draw_row(row);
   }
 }
 
-int fb_putchar(int c) {
-  bool stay = false;
+static void clear_line_segment(uint64_t row, uint32_t start_col, uint32_t end_col, const ansi_style_t* style) {
+  ensure_row(row, style);
+  console_cell_t* cells = cell_at(row, 0);
+  ansi_style_t fill_style = style ? *style : default_style;
 
-  switch(c) {
-    case '\0': {
-      ansi_code = false;
-      return 0;
+  for(uint32_t col = start_col; col <= end_col && col < visible_cols; col++) {
+    cells[col].ch = ' ';
+    cells[col].style = fill_style;
+  }
+
+  draw_row(row);
+}
+
+static void advance_line(void) {
+  cursor_col = 0;
+  cursor_row++;
+  ensure_row(cursor_row, &current_style);
+  clear_line_segment(cursor_row, 0, visible_cols - 1, &current_style);
+
+  if(cursor_row + 1 > total_rows) {
+    total_rows = cursor_row + 1;
+  }
+
+  sync_viewport_to_cursor();
+}
+
+static void carriage_return(void) {
+  cursor_col = 0;
+}
+
+static void tab_forward(void) {
+  uint32_t spaces = 8 - (cursor_col % 8);
+  for(uint32_t i = 0; i < spaces; i++) {
+    fb_putchar(' ');
+  }
+}
+
+static void backspace(void) {
+  if(cursor_col == 0) {
+    return;
+  }
+  cursor_col--;
+  ensure_row(cursor_row, &default_style);
+  console_cell_t* cell = cell_at(cursor_row, cursor_col);
+  cell->ch = ' ';
+  draw_cell(cursor_row, cursor_col);
+}
+
+static void write_char(int c) {
+  ensure_row(cursor_row, &current_style);
+  console_cell_t* cell = cell_at(cursor_row, cursor_col);
+  cell->ch = (char)c;
+  cell->style = current_style;
+  draw_cell(cursor_row, cursor_col);
+
+  cursor_col++;
+  if(cursor_col >= visible_cols) {
+    advance_line();
+  }
+}
+
+static void cursor_move_vertical(int delta) {
+  if(delta == 0) {
+    return;
+  }
+
+  if(delta > 0) {
+    cursor_row += (uint64_t)delta;
+  } else {
+    uint64_t magnitude = (uint64_t)(-delta);
+    if(cursor_row < magnitude) {
+      cursor_row = 0;
+    } else {
+      cursor_row -= magnitude;
     }
-    case '\b': {
-      ansi_code = false;
-      stay = true;
-      if(current_col > 0) {
-        current_col--;
-        c = ' ';
+  }
+
+  if(cursor_row >= total_rows) {
+    total_rows = cursor_row + 1;
+  }
+
+  ensure_row(cursor_row, &default_style);
+  sync_viewport_to_cursor();
+  draw_row(cursor_row);
+}
+
+static void cursor_move_horizontal(int delta) {
+  int64_t new_col = (int64_t)cursor_col + delta;
+  if(new_col < 0) {
+    cursor_col = 0;
+  } else if((uint32_t)new_col >= visible_cols) {
+    cursor_col = visible_cols - 1;
+  } else {
+    cursor_col = (uint32_t)new_col;
+  }
+}
+
+static void set_cursor_position(uint64_t row, uint32_t col) {
+  cursor_row = row;
+  cursor_col = col < visible_cols ? col : (visible_cols - 1);
+
+  if(cursor_row >= total_rows) {
+    total_rows = cursor_row + 1;
+  }
+
+  ensure_row(cursor_row, &default_style);
+  sync_viewport_to_cursor();
+  draw_row(cursor_row);
+}
+
+static void clear_screen(uint32_t mode) {
+  switch(mode) {
+    case 0: {
+      clear_line_segment(cursor_row, cursor_col, visible_cols - 1, &current_style);
+      if(cursor_row + 1 < total_rows) {
+        clear_range(cursor_row + 1, 0, total_rows - 1, visible_cols - 1, &default_style);
       }
       break;
     }
-    case '\x1b': {
-      ansi_code = true;
-      ansi_color = 0;
-      return 0;
-    }
-    case '\n': {
-      ansi_code = false;
-      current_col = 0;
-      current_row++;
-      if(current_row >= ROWS) {
-        current_row = ROWS - 1;
-        fb_scroll_up(1);
+    case 1: {
+      if(cursor_row > 0) {
+        clear_range(0, 0, cursor_row - 1, visible_cols - 1, &default_style);
       }
-      return 0;
+      clear_line_segment(cursor_row, 0, cursor_col, &default_style);
+      break;
+    }
+    case 2:
+    default: {
+      cursor_row = 0;
+      cursor_col = 0;
+      viewport_row = 0;
+      total_rows = visible_rows;
+      for(uint32_t row = 0; row < visible_rows; row++) {
+        ensure_row(row, &default_style);
+        clear_line_segment(row, 0, visible_cols - 1, &default_style);
+      }
+      render_viewport();
+      break;
     }
   }
+}
 
-  if(ansi_code) {
-    switch (c) {
-      case '0':
-      case '1':
-      case '2':
-      case '3':
-      case '4':
-      case '5':
-      case '6':
-      case '7':
-      case '8':
-      case '9': {
-        ansi_color = (ansi_color * 10) + (c - '0');
-        break;
+static void clear_line(uint32_t mode) {
+  switch(mode) {
+    case 0:
+      clear_line_segment(cursor_row, cursor_col, visible_cols - 1, &current_style);
+      break;
+    case 1:
+      clear_line_segment(cursor_row, 0, cursor_col, &current_style);
+      break;
+    case 2:
+    default:
+      clear_line_segment(cursor_row, 0, visible_cols - 1, &current_style);
+      break;
+  }
+}
+
+static int get_csi_param(size_t index, int default_value) {
+  if(index >= csi_param_count) {
+    return default_value;
+  }
+  return csi_params[index];
+}
+
+static void handle_csi_command(char final_byte) {
+  if(csi_private_sequence) {
+    ansi_state = ANSI_STATE_NORMAL;
+    return;
+  }
+
+  switch(final_byte) {
+    case 'A': {
+      int amount = get_csi_param(0, 1);
+      cursor_move_vertical(-amount);
+      break;
+    }
+    case 'B': {
+      int amount = get_csi_param(0, 1);
+      cursor_move_vertical(amount);
+      break;
+    }
+    case 'C': {
+      int amount = get_csi_param(0, 1);
+      cursor_move_horizontal(amount);
+      break;
+    }
+    case 'D': {
+      int amount = get_csi_param(0, 1);
+      cursor_move_horizontal(-amount);
+      break;
+    }
+    case 'E': {
+      int amount = get_csi_param(0, 1);
+      cursor_move_vertical(amount);
+      cursor_col = 0;
+      break;
+    }
+    case 'F': {
+      int amount = get_csi_param(0, 1);
+      cursor_move_vertical(-amount);
+      cursor_col = 0;
+      break;
+    }
+    case 'G': {
+      int column = get_csi_param(0, 1);
+      if(column < 1) {
+        column = 1;
       }
-      case ';': {
-        break;
+      cursor_move_horizontal(column - 1 - (int)cursor_col);
+      break;
+    }
+    case 'H':
+    case 'f': {
+      int row = get_csi_param(0, 1);
+      int col = get_csi_param(1, 1);
+      if(row < 1) {
+        row = 1;
       }
-      case 'm':
-        ansi_code = false;
-        break;
+      if(col < 1) {
+        col = 1;
       }
+      set_cursor_position(viewport_row + (uint64_t)(row - 1), (uint32_t)(col - 1));
+      break;
+    }
+    case 'J': {
+      uint32_t mode = (uint32_t)get_csi_param(0, 0);
+      clear_screen(mode);
+      break;
+    }
+    case 'K': {
+      uint32_t mode = (uint32_t)get_csi_param(0, 0);
+      clear_line(mode);
+      break;
+    }
+    case 'S': {
+      int amount = get_csi_param(0, 1);
+      if(amount < 0) {
+        amount = 0;
+      }
+      scroll_region_up((uint32_t)amount);
+      break;
+    }
+    case 'T': {
+      int amount = get_csi_param(0, 1);
+      if(amount < 0) {
+        amount = 0;
+      }
+      scroll_region_down((uint32_t)amount);
+      break;
+    }
+    case 'm': {
+      ansi_style_apply_sgr(&current_style, csi_params, csi_param_count);
+      break;
+    }
+    case 's': {
+      saved_cursor_row = cursor_row;
+      saved_cursor_col = cursor_col;
+      saved_style = current_style;
+      has_saved_cursor = true;
+      break;
+    }
+    case 'u': {
+      if(has_saved_cursor) {
+        cursor_row = saved_cursor_row;
+        cursor_col = saved_cursor_col;
+        current_style = saved_style;
+        sync_viewport_to_cursor();
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+static void csi_start(void) {
+  csi_param_count = 0;
+  csi_param_active = false;
+  csi_private_sequence = false;
+}
+
+static void csi_finish_param(void) {
+  if(!csi_param_active) {
+    csi_params[csi_param_count++] = 0;
+  } else {
+    csi_param_count++;
+  }
+  csi_param_active = false;
+}
+
+int fb_putchar(int c) {
+  if(!active) {
     return 0;
   }
 
-  glypht_t glyph = font_glyph(c);
-
-  int x = (current_col * char_line_width) + 10;
-  int y = (current_row * char_line_height) + 10;
-
-  // fb_drawline(x, y, fb_width(), y, 0xff0000);
-  // fb_drawline(x, y, x, fb_height(), 0xff0000);
-
-  for(int gx = 0; gx < 8; gx++) {
-    for(int gy = 0; gy < 16; gy++) {
-      fb_putpixel(x + gx, y + gy, color_bg);
-      if((glyph.points[gy] >> (7 - gx)) & 0x01) {
-        fb_putpixel(x + gx, y + gy, color_fg);
+  switch(ansi_state) {
+    case ANSI_STATE_NORMAL: {
+      switch(c) {
+        case '\x1b':
+          ansi_state = ANSI_STATE_ESCAPE;
+          return 0;
+        case '\n':
+          advance_line();
+          sync_viewport_to_cursor();
+          return 0;
+        case '\r':
+          carriage_return();
+          return 0;
+        case '\t':
+          tab_forward();
+          return 0;
+        case '\b':
+          backspace();
+          return 0;
+        case '\0':
+          return 0;
+        default:
+          if(c >= ' ') {
+            write_char(c);
+          }
+          return 0;
       }
     }
-  }
-  if(current_col < COLS){
-    if(!stay) {
-      current_col++;
+    case ANSI_STATE_ESCAPE: {
+      if(c == '[') {
+        ansi_state = ANSI_STATE_CSI;
+        csi_start();
+        return 0;
+      }
+      ansi_state = ANSI_STATE_NORMAL;
+      return 0;
     }
-  } else {
-    current_col = 0;
-    current_row++;
-    if(current_row >= ROWS) {
-      current_row = ROWS - 1;
-      fb_scroll_up(1);
+    case ANSI_STATE_CSI: {
+      if(c == '?') {
+        csi_private_sequence = true;
+        return 0;
+      }
+
+      if(c >= '0' && c <= '9') {
+        if(!csi_param_active) {
+          if(csi_param_count < CSI_MAX_PARAMS) {
+            csi_params[csi_param_count] = 0;
+          }
+          csi_param_active = true;
+        }
+        if(csi_param_count < CSI_MAX_PARAMS) {
+          csi_params[csi_param_count] = (csi_params[csi_param_count] * 10) + (c - '0');
+        }
+        return 0;
+      }
+
+      if(c == ';') {
+        if(csi_param_count < CSI_MAX_PARAMS) {
+          csi_finish_param();
+        }
+        return 0;
+      }
+
+      if(csi_param_active && csi_param_count < CSI_MAX_PARAMS) {
+        csi_finish_param();
+      }
+
+      handle_csi_command((char)c);
+      ansi_state = ANSI_STATE_NORMAL;
+      return 0;
     }
   }
 
@@ -248,9 +747,67 @@ void fb_list_modes() {
 }
 
 void set_foreground_color(uint32_t color) {
-  color_fg = color;
+  switch(color) {
+    case FB_BLACK: current_style.fg = 0; break;
+    case FB_DARK_RED: current_style.fg = 1; break;
+    case FB_DARK_GREEN: current_style.fg = 2; break;
+    case FB_DARK_YELLOW: current_style.fg = 3; break;
+    case FB_DARK_BLUE: current_style.fg = 4; break;
+    case FB_DARK_MAGENTA: current_style.fg = 5; break;
+    case FB_DARK_CYAN: current_style.fg = 6; break;
+    case FB_WHITE: current_style.fg = 7; break;
+    case FB_LIGHT_BLACK: current_style.fg = 8; break;
+    case FB_RED: current_style.fg = 9; break;
+    case FB_GREEN: current_style.fg = 10; break;
+    case FB_YELLOW: current_style.fg = 11; break;
+    case FB_BLUE: current_style.fg = 12; break;
+    case FB_MAGENTA: current_style.fg = 13; break;
+    case FB_CYAN: current_style.fg = 14; break;
+    case FB_LIGHT_WHITE: current_style.fg = 15; break;
+    case FB_ORANGE: current_style.fg = 11; break;
+    default: current_style.fg = 7; break;
+  }
+  default_style.fg = current_style.fg;
 }
 
 void set_background_color(uint32_t color) {
-  color_bg = color;
+  switch(color) {
+    case FB_BLACK: current_style.bg = 0; break;
+    case FB_DARK_RED: current_style.bg = 1; break;
+    case FB_DARK_GREEN: current_style.bg = 2; break;
+    case FB_DARK_YELLOW: current_style.bg = 3; break;
+    case FB_DARK_BLUE: current_style.bg = 4; break;
+    case FB_DARK_MAGENTA: current_style.bg = 5; break;
+    case FB_DARK_CYAN: current_style.bg = 6; break;
+    case FB_WHITE: current_style.bg = 7; break;
+    case FB_LIGHT_BLACK: current_style.bg = 8; break;
+    case FB_RED: current_style.bg = 9; break;
+    case FB_GREEN: current_style.bg = 10; break;
+    case FB_YELLOW: current_style.bg = 11; break;
+    case FB_BLUE: current_style.bg = 12; break;
+    case FB_MAGENTA: current_style.bg = 13; break;
+    case FB_CYAN: current_style.bg = 14; break;
+    case FB_LIGHT_WHITE: current_style.bg = 15; break;
+    case FB_ORANGE: current_style.bg = 11; break;
+    default: current_style.bg = 0; break;
+  }
+  default_style.bg = current_style.bg;
+}
+
+void fb_scroll_up(int lines) {
+  if(lines <= 0) {
+    return;
+  }
+
+  uint64_t max_view = max_viewport_row();
+  uint64_t new_view = viewport_row + (uint64_t)lines;
+  if(new_view > max_view) {
+    new_view = max_view;
+  }
+  viewport_row = new_view;
+  render_viewport();
+}
+
+void fb_draw() {
+  render_viewport();
 }

--- a/tasks.json
+++ b/tasks.json
@@ -1,0 +1,99 @@
+[
+  {
+    "title": "Align kernel thread sleep state with scheduler enums",
+    "body": "## Goal\nEnsure `ksleep` marks threads with a valid scheduler state so the kernel builds and the scheduler can detect sleeping threads.\n\n## Context\n`kthread.c` uses `THREAD_SLEEPING`, but no such constant exists. The process scheduler expects `PROC_STATE_SLEEPING`. The mismatch currently prevents compilation and keeps the scheduler from tracking sleep state correctly.\n\n## Definition of Done\n- Replace the undefined `THREAD_SLEEPING` in `kthread.c` with the appropriate scheduler state constant (e.g., `PROC_STATE_SLEEPING`).\n- Verify that the kernel compiles without introducing new warnings.\n- Confirm that sleeping threads transition to the correct state in scheduler diagnostics/logs.\n",
+    "labels": ["bug"],
+    "github_issue": {
+      "number": 10,
+      "url": "https://github.com/pbalduino/menios/issues/10",
+      "state": "OPEN"
+    }
+  },
+  {
+    "title": "Propagate kernel thread termination status for joins",
+    "body": "## Goal\nAllow `ktread_join` to detect when a thread has exited so callers can synchronise correctly.\n\n## Context\n`kthread_t.status` is never initialised or updated. `ktread_join` busy-waits on `THREAD_TERMINATED`, but that flag never changes, causing joins to spin forever on uninitialised memory.\n\n## Definition of Done\n- Initialise `kthread_t.status` to a running state when creating a thread.\n- Set the status to `THREAD_TERMINATED` when the entrypoint returns or `kexit` completes.\n- Ensure `ktread_join` exits once the status flips, and document/update any state transitions touched.\n- Add or update logging/tests as needed to show the status change occurs.\n",
+    "labels": ["bug"],
+    "github_issue": {
+      "number": 11,
+      "url": "https://github.com/pbalduino/menios/issues/11",
+      "state": "OPEN"
+    }
+  },
+  {
+    "title": "Calibrate TSC timekeeping and initialise boot time",
+    "body": "## Goal\nProduce accurate microsecond timestamps from `unix_time_us` by initialising boot time and converting TSC ticks using a measured frequency.\n\n## Context\n`unix_time_us` currently divides raw TSC ticks by 1000 and adds `boot_time_sec`, but the frequency is never calibrated and `boot_time_sec` stays zero. Timers, scheduler accounting, and sleep logic therefore run with incorrect timings.\n\n## Definition of Done\n- Determine TSC frequency (via calibration against LAPIC/HPET/PIT or CPUID invariant data) and use it to convert cycles to real time.\n- Initialise `boot_time_sec` (e.g., from Limine boot time request) before `unix_time_us` is first called.\n- Update `ksleep`, scheduler accounting, and related code if they assume nanoseconds-per-cycle is 1.\n- Validate with logs or tests that reported durations roughly match wall-clock expectations.\n",
+    "labels": ["bug"],
+    "github_issue": {
+      "number": 12,
+      "url": "https://github.com/pbalduino/menios/issues/12",
+      "state": "OPEN"
+    }
+  },
+  {
+    "title": "Fix the PF handler to show the right data",
+    "body": "## Goal\nFix the page fault handler to display complete and accurate CPU state information when a page fault occurs.\n\n## Context\nThere's a mismatch in the page fault handler implementation between the assembly code and C handlers. The ASM handler in `lidt.s:116` calls `page_fault_handler(stack_frame_t* stack_frame)`, but there's also a separate `idt_pf_isr_handler(uint64_t error_code)` in `idt.c:66`. The current handler shows basic information (error code, CR2 register) but may be missing comprehensive CPU state due to this handler mismatch.\n\n## Definition of Done\n- Resolve the function signature mismatch between assembly and C page fault handlers\n- Display complete CPU register state (RAX, RBX, RCX, RDX, RSI, RDI, etc.) \n- Show proper page fault analysis (present bit, write/read access, user/kernel mode)\n- Provide accurate virtual address (CR2) and detailed error code breakdown\n- Ensure the handler receives and displays correct stack frame information\n- Verify page fault debugging information is comprehensive and accurate",
+    "labels": ["bug"],
+    "github_issue": {
+      "number": 4,
+      "url": "https://github.com/pbalduino/menios/issues/4",
+      "state": "OPEN"
+    }
+  },
+  {
+    "title": "Fix the GPF handler to show the right data",
+    "body": "## Goal\nEnhance the General Protection Fault (GPF) handler to display comprehensive CPU state and error analysis when a GPF occurs.\n\n## Context\nThe current GPF handler in `idt.c:57-64` and `lidt.s:56-94` properly saves all registers but only displays limited information (R15 register and error code). The handler uses `dump_heap()` to show memory state but lacks comprehensive register display and error code analysis to help diagnose what caused the GPF.\n\n## Definition of Done\n- Display complete CPU register state (RAX, RBX, RCX, RDX, RSI, RDI, RSP, RBP, etc.) instead of just R15\n- Analyze and decode the error code to explain the GPF cause (invalid segment, privilege violation, etc.)\n- Show instruction pointer (RIP) and segment information (CS, DS, SS, etc.)\n- Provide meaningful error messages explaining the type of protection violation\n- Maintain the existing register preservation but improve the diagnostic output\n- Ensure the handler provides actionable debugging information for GPF diagnosis",
+    "labels": ["bug"],
+    "github_issue": {
+      "number": 5,
+      "url": "https://github.com/pbalduino/menios/issues/5",
+      "state": "OPEN"
+    }
+  },
+  {
+    "title": "Fix kmalloc to get memory from the virtual memory",
+    "body": "## Goal\nIntegrate kmalloc with the virtual memory management system instead of using direct physical memory allocation.\n\n## Context\nThe current kmalloc implementation in `kmalloc.c` uses a simple heap allocator with a linked list of nodes, operating directly on physical memory addresses. The heap is initialized with a fixed address and size via `init_heap(void* addr, size_t size)` but doesn't integrate with the virtual memory manager. The existing `get_first_free_page()` function is available but not used by kmalloc.\n\n## Definition of Done\n- Modify kmalloc to allocate pages from the virtual memory manager instead of direct physical memory\n- Integrate with the existing page allocation system (`get_first_free_page()` function)\n- Implement proper virtual-to-physical address mapping for allocated memory\n- Ensure kmalloc works with the page fault handler for demand paging scenarios\n- Update heap initialization to use virtual memory addresses rather than physical addresses\n- Maintain backwards compatibility with existing kmalloc users while improving the underlying memory management\n- Verify that freed memory is properly returned to the virtual memory system",
+    "labels": ["enhancement"],
+    "github_issue": {
+      "number": 6,
+      "url": "https://github.com/pbalduino/menios/issues/6",
+      "state": "OPEN"
+    }
+  },
+  {
+    "title": "Fix virtual_to_physical calculation",
+    "body": "## Goal\nReplace the overly simplistic virtual_to_physical calculation with a proper page table walking implementation.\n\n## Context\nThe current `virtual_to_physical` function in `pmm.c:43-45` uses a basic calculation `return virtual_address - kernel_offset` which only works for kernel direct-mapped memory (HHDM - Higher Half Direct Map). This approach doesn't handle user space virtual addresses, doesn't walk the actual page tables, and assumes linear mapping which may not be true for all memory regions.\n\n## Definition of Done\n- Implement proper page table hierarchy walking (PML4 → PDPT → PD → PT) to find actual physical mappings\n- Handle different memory regions correctly (kernel space, user space, device memory)\n- Return appropriate error codes for unmapped virtual addresses or invalid page table entries\n- Integrate with the existing paging structures already defined in the codebase\n- Ensure the function works correctly for both kernel and user virtual addresses\n- Add proper bounds checking and validation of page table entries\n- Maintain performance while providing accurate virtual-to-physical translation\n- Add documentation explaining the page table walking process",
+    "labels": ["bug"],
+    "github_issue": {
+      "number": 7,
+      "url": "https://github.com/pbalduino/menios/issues/7",
+      "state": "OPEN"
+    }
+  },
+  {
+    "title": "Add ANSI and scrolling to the console",
+    "body": "## Goal\nImplement comprehensive ANSI escape sequence support and enhanced scrolling functionality for the console.\n\n## Context\nThe current console implementation in `framebuffer.c:148-188` has basic ANSI escape sequence detection that handles color codes but is incomplete. It only processes ESC, digits, semicolons, and 'm' commands without actual color setting. The scrolling implementation in `fb_scroll_up()` only scrolls up one line at a time with no scrollback buffer or smooth scrolling capabilities.\n\n## Definition of Done\n- Implement full ANSI escape sequence support for cursor movement commands (`\\x1b[H` for home, `\\x1b[2J` for clear screen, etc.)\n- Add comprehensive color palette support (minimum 16 colors) with proper color setting functionality\n- Implement text attributes support (bold, dim, underline, reverse video)\n- Add cursor positioning commands and screen clearing functionality\n- Implement scrollback buffer to allow viewing previous screen content\n- Add smooth scrolling capabilities beyond the current single-line scrolling\n- Ensure ANSI processing is complete and handles edge cases properly\n- Test with various ANSI escape sequences to verify compatibility\n- Document the supported ANSI codes and their implementation",
+    "labels": ["enhancement"],
+    "status": "In Review",
+    "branch": "issue-8-ansi-scrolling",
+    "pull_request": {
+      "title": "Complete ANSI console support (#8)",
+      "draft": true
+    },
+    "github_issue": {
+      "number": 8,
+      "url": "https://github.com/pbalduino/menios/issues/8",
+      "state": "OPEN",
+      "assignee": "pbalduino"
+    }
+  },
+  {
+    "title": "Complete the vsprintk function and add tests",
+    "body": "## Goal\nComplete the missing format specifiers in vsprintk and ensure all existing tests pass.\n\n## Context\nThe vsprintk function in `vprintk.c` is quite complete with support for basic format specifiers (`%c`, `%d`, `%u`, `%x`, `%X`, `%s`, `%p`, `%ld`, `%lx`) and padding/width features. However, several format specifiers have tests written in `test_vsprintk.c` but are not implemented: `%llu`, `%-` (left align), precision support (`.`), `%*` (dynamic width), `%#` (alternate form), and `%%` (literal percent).\n\n## Definition of Done\n- Implement `%llu` (unsigned long long) support to handle 64-bit unsigned integers\n- Add `%-` (left align) support for left-justified output formatting\n- Uncomment and complete precision support (`.` specifier) that is currently disabled in lines 246-253\n- Implement `%*` (dynamic width) support for runtime width specification\n- Add `%#` (alternate form) support for hex formatting with 0x prefix\n- Implement `%%` (literal percent) support to output a single percent character\n- Ensure all existing tests in `test_vsprintk.c` pass without modification\n- Add additional edge case tests for the newly implemented features\n- Verify compatibility with standard printf behavior for the implemented specifiers",
+    "labels": ["enhancement"],
+    "github_issue": {
+      "number": 9,
+      "url": "https://github.com/pbalduino/menios/issues/9",
+      "state": "OPEN"
+    }
+  }
+]

--- a/test/test_ansi.c
+++ b/test/test_ansi.c
@@ -1,0 +1,73 @@
+#include <kernel/ansi.h>
+
+#include <unity.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+static void assert_colors(uint8_t fg_index, uint8_t bg_index, uint8_t attrs, uint32_t expected_fg, uint32_t expected_bg) {
+  ansi_style_t style = {.fg = fg_index, .bg = bg_index, .attrs = attrs};
+  uint32_t fg;
+  uint32_t bg;
+  ansi_style_effective_colors(&style, &fg, &bg);
+  TEST_ASSERT_EQUAL_HEX32(expected_fg, fg);
+  TEST_ASSERT_EQUAL_HEX32(expected_bg, bg);
+}
+
+void test_ansi_reset_sets_white_on_black(void) {
+  ansi_style_t style = {.fg = 3, .bg = 4, .attrs = 0xff};
+  ansi_style_reset(&style);
+  TEST_ASSERT_EQUAL_UINT8(7, style.fg);
+  TEST_ASSERT_EQUAL_UINT8(0, style.bg);
+  TEST_ASSERT_EQUAL_UINT8(0, style.attrs);
+}
+
+void test_ansi_bold_promotes_to_bright_variant(void) {
+  ansi_style_t style;
+  ansi_style_reset(&style);
+  int params[] = {31, 1};
+  ansi_style_apply_sgr(&style, params, 2);
+  TEST_ASSERT_EQUAL_UINT8(9, style.fg);
+  TEST_ASSERT_EQUAL_UINT8(0, style.bg);
+  TEST_ASSERT_TRUE(style.attrs & ANSI_ATTR_BOLD);
+}
+
+void test_ansi_dim_clears_bold_and_darksen_color(void) {
+  ansi_style_t style;
+  ansi_style_reset(&style);
+  int params[] = {32, 1, 2};
+  ansi_style_apply_sgr(&style, params, 3);
+  uint32_t fg;
+  uint32_t bg;
+  ansi_style_effective_colors(&style, &fg, &bg);
+  TEST_ASSERT_EQUAL_UINT8(2, style.fg);
+  TEST_ASSERT_EQUAL_HEX32(ansi_dim_color(ansi_palette_color(10)), fg);
+  TEST_ASSERT_EQUAL_HEX32(ansi_palette_color(0), bg);
+  TEST_ASSERT_TRUE(style.attrs & ANSI_ATTR_DIM);
+  TEST_ASSERT_FALSE(style.attrs & ANSI_ATTR_BOLD);
+}
+
+void test_ansi_reverse_swaps_colors(void) {
+  assert_colors(4, 7, ANSI_ATTR_REVERSE, ansi_palette_color(7), ansi_palette_color(4));
+}
+
+void test_ansi_color_selection_handles_extended_ranges(void) {
+  ansi_style_t style;
+  ansi_style_reset(&style);
+  int params[] = {94, 102};
+  ansi_style_apply_sgr(&style, params, 2);
+  TEST_ASSERT_EQUAL_UINT8( (uint8_t)(8 + (94 - 90)), style.fg);
+  TEST_ASSERT_EQUAL_UINT8( (uint8_t)(8 + (102 - 100)), style.bg);
+}
+
+int main(void) {
+  UNITY_BEGIN();
+
+  RUN_TEST(test_ansi_reset_sets_white_on_black);
+  RUN_TEST(test_ansi_bold_promotes_to_bright_variant);
+  RUN_TEST(test_ansi_dim_clears_bold_and_darksen_color);
+  RUN_TEST(test_ansi_reverse_swaps_colors);
+  RUN_TEST(test_ansi_color_selection_handles_extended_ranges);
+
+  return UNITY_END();
+}


### PR DESCRIPTION
  ## Summary
  - replace the pixel-shift console with a styled scrollback buffer and CSI command handling
  - map ANSI SGR codes onto a shared 16-colour palette with bold/dim/reverse support
  - add Unity coverage for the ANSI style helper and note the work in tasks.json

  ## Testing
  - gcc -Iinclude test/unity.c test/stubs.c test/test_ansi.c src/kernel/console/ansi.c -o test_ansi
  - ./test_ansi