### PR TITLE
Feature/scheduler refactor

### DIFF
--- a/CODING.md
+++ b/CODING.md
@@ -191,6 +191,34 @@ This document outlines the coding style guidelines for meniOS, inspired by the L
     #endif
     ```
 
+## 6. Commit Messages
+
+- **Rule**: Use past tense for commit messages to describe what was done.
+
+- **Good Examples**:
+
+    ```
+    Fixed buffer overflow in vsprintk
+
+    Added support for ARM64 boot protocol
+
+    Refactored scheduler to keep per-process frames
+    ```
+
+- **Bad Examples**:
+
+    ```
+    Fix buffer overflow          # Present tense
+    add arm64 support            # Uncapitalized, present tense
+    Refactor the scheduler code  # Present tense
+    ```
+
+- **Additional Guidelines**:
+  - Keep the first line under 72 characters
+  - Capitalize the first letter
+  - Use the body to explain *what* and *why*, not *how*
+  - Reference relevant issues with `#issue-number`
+
 For any scenarios or coding practices not covered by this document, please refer to the Linux Coding Style guidelines. Updates to this document will be communicated as necessary.
 
 By following these guidelines, the meniOS codebase will maintain a consistent and readable format, improving collaboration and code maintenance.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -179,6 +179,28 @@ We welcome various types of contributions:
    - References to issues or tasks addressed"
    ```
 
+   **Commit Message Guidelines**:
+   - Use **past tense** for commit messages (e.g., "Fixed", "Added", "Refactored", not "Fix", "Add", "Refactor")
+   - Keep the first line under 72 characters
+   - Use the body to explain *what* and *why*, not *how*
+   - Reference relevant issues with `#issue-number`
+
+   **Good Examples**:
+   ```
+   Fixed buffer overflow in vsprintk
+
+   Added support for ARM64 boot protocol
+
+   Refactored scheduler to keep per-process frames
+   ```
+
+   **Bad Examples**:
+   ```
+   Fix buffer overflow          # Present tense
+   add arm64 support            # Uncapitalized, present tense
+   Refactor the scheduler code  # Present tense
+   ```
+
 2. **Push and Create PR**
    ```bash
    git push origin feature/your-feature-name

--- a/app/mosh/mosh.c
+++ b/app/mosh/mosh.c
@@ -54,6 +54,11 @@ static size_t str_len(const char* s);
 static bool   str_eq(const char* a, const char* b);
 static void   str_copy(char* dest, size_t capacity, const char* src);
 static bool   strip_background_marker(char* text);
+static void   debug_write_ptr(int fd, const void* ptr);
+static void   debug_log_expand_start(const char* input, char* output, size_t capacity);
+static void   debug_log_expand_dollar(const char* cursor);
+static void   debug_dump_bytes(const char* label, const char* data);
+static bool   debug_ptr_readable(const void* ptr);
 
 typedef struct {
   char*  argv[MOSH_MAX_ARGS];
@@ -1181,6 +1186,144 @@ static bool shell_append_text(char* output, size_t capacity, size_t* index, cons
   return true;
 }
 
+static bool shell_expand_emit_dollar_literal(const char** cursor,
+                                             char* output,
+                                             size_t capacity,
+                                             size_t* out_index) {
+  if(output == NULL || cursor == NULL || *cursor == NULL || out_index == NULL) {
+    return false;
+  }
+  if(*out_index + 1 >= capacity) {
+    return false;
+  }
+  output[(*out_index)++] = '$';
+  (*cursor)++;
+  return true;
+}
+
+static bool shell_expand_dollar(const char** cursor,
+                                char* output,
+                                size_t capacity,
+                                size_t* out_index) {
+  if(cursor == NULL || *cursor == NULL) {
+    return false;
+  }
+
+  const char* dollar = *cursor;
+  write_str(STDERR_FILENO, "[mosh] dollar enter ptr=");
+  debug_write_ptr(STDERR_FILENO, dollar);
+  write_str(STDERR_FILENO, " next=");
+  if(debug_ptr_readable(dollar)) {
+    char ch = *dollar;
+    char buf[4] = { ch, '\0', '\0', '\0' };
+    if(ch == '\n') {
+      write_str(STDERR_FILENO, "\\n");
+    } else if(ch == '\r') {
+      write_str(STDERR_FILENO, "\\r");
+    } else {
+      write_str(STDERR_FILENO, buf);
+    }
+  } else {
+    write_str(STDERR_FILENO, "<invalid>");
+  }
+  write_str(STDERR_FILENO, "\n");
+  if(output == NULL || out_index == NULL) {
+    return false;
+  }
+
+  if(!debug_ptr_readable(dollar) || !debug_ptr_readable(dollar + 1)) {
+    write_str(STDERR_FILENO, "[mosh] dollar fallback invalid cursor\n");
+    return shell_expand_emit_dollar_literal(cursor, output, capacity, out_index);
+  }
+
+  char name_buffer[MOSH_MAX_VAR_NAME];
+  size_t name_len = 0;
+  bool overflow = false;
+
+  const char* ptr = dollar + 1;
+  char next = *ptr;
+  if(next == '\0') {
+    return shell_expand_emit_dollar_literal(cursor, output, capacity, out_index);
+  }
+
+  if(next == '$') {
+    if(*out_index + 1 >= capacity) {
+      return false;
+    }
+    output[(*out_index)++] = '$';
+    *cursor = ptr + 1;
+    return true;
+  }
+
+  if(next == '{') {
+    ptr++;
+    while(*ptr != '\0' && *ptr != '}') {
+      if(name_len + 1 >= sizeof(name_buffer)) {
+        overflow = true;
+      } else {
+        name_buffer[name_len++] = *ptr;
+      }
+      ptr++;
+    }
+
+    if(*ptr != '}') {
+      return shell_expand_emit_dollar_literal(cursor, output, capacity, out_index);
+    }
+
+    if(overflow || name_len == 0) {
+      return shell_expand_emit_dollar_literal(cursor, output, capacity, out_index);
+    }
+
+    name_buffer[name_len] = '\0';
+    const char* value = shell_var_get(name_buffer);
+    if(value == NULL) {
+      value = "";
+    }
+    if(!shell_append_text(output, capacity, out_index, value)) {
+      return false;
+    }
+    *cursor = ptr + 1;
+    return true;
+  }
+
+  if(shell_is_digit(next)) {
+    while(shell_is_digit(*ptr)) {
+      if(name_len + 1 >= sizeof(name_buffer)) {
+        overflow = true;
+      } else {
+        name_buffer[name_len++] = *ptr;
+      }
+      ptr++;
+    }
+  } else if(shell_is_ident_start(next)) {
+    while(shell_is_ident_char(*ptr)) {
+      if(name_len + 1 >= sizeof(name_buffer)) {
+        overflow = true;
+      } else {
+        name_buffer[name_len++] = *ptr;
+      }
+      ptr++;
+    }
+  } else {
+    return shell_expand_emit_dollar_literal(cursor, output, capacity, out_index);
+  }
+
+  if(name_len == 0 || overflow) {
+    return shell_expand_emit_dollar_literal(cursor, output, capacity, out_index);
+  }
+
+  name_buffer[name_len] = '\0';
+  const char* value = shell_var_get(name_buffer);
+  if(value == NULL) {
+    value = "";
+  }
+  if(!shell_append_text(output, capacity, out_index, value)) {
+    return false;
+  }
+  *cursor = ptr;
+  return true;
+}
+
 static bool shell_expand_variables(const char* input, char* output, size_t capacity) {
   if(output == NULL || capacity == 0) {
     return false;
@@ -1190,87 +1333,101 @@ static bool shell_expand_variables(const char* input, char* output, size_t capac
     return true;
   }
 
+  debug_log_expand_start(input, output, capacity);
+
   size_t out_index = 0;
   output[0] = '\0';
 
-  for(size_t i = 0; input[i] != '\0'; i++) {
-    char ch = input[i];
-    if(ch == '$') {
-      i++;
-      if(input[i] == '\0') {
-        if(out_index + 1 >= capacity) {
-          return false;
-        }
-        output[out_index++] = '$';
-        break;
-      }
+  const char* cursor = input;
+  while(true) {
+    if(!debug_ptr_readable(cursor)) {
+      write_str(STDERR_FILENO, "[mosh] expand invalid cursor=");
+      debug_write_ptr(STDERR_FILENO, cursor);
+      write_str(STDERR_FILENO, "\n");
+      return false;
+    }
+    char ch = *cursor;
+    write_str(STDERR_FILENO, "[mosh] expand char ptr=");
+    debug_write_ptr(STDERR_FILENO, cursor);
+    write_str(STDERR_FILENO, " ch=");
+    char display[5];
+    display[0] = ch;
+    display[1] = '\0';
+    if(ch == '\n') {
+      write_str(STDERR_FILENO, "\\n");
+    } else if(ch == '\r') {
+      write_str(STDERR_FILENO, "\\r");
+    } else {
+      write_str(STDERR_FILENO, display);
+    }
+    write_str(STDERR_FILENO, "\n");
+    if(ch == '\0') {
+      break;
+    }
 
-      if(input[i] == '$') {
+    if(ch == '$') {
+      write_str(STDERR_FILENO, "[mosh] dollar guard cursor=");
+      debug_write_ptr(STDERR_FILENO, cursor);
+      write_str(STDERR_FILENO, " next=");
+      const char* next_ptr = cursor + 1;
+      debug_write_ptr(STDERR_FILENO, next_ptr);
+      write_str(STDERR_FILENO, " ch=");
+      if(debug_ptr_readable(cursor)) {
+        char current = *cursor;
+        if(current == '\n') {
+          write_str(STDERR_FILENO, "\\n");
+        } else if(current == '\r') {
+          write_str(STDERR_FILENO, "\\r");
+        } else {
+          char buf[2] = { current, '\0' };
+          write_str(STDERR_FILENO, buf);
+        }
+      } else {
+        write_str(STDERR_FILENO, "<invalid>");
+      }
+      write_str(STDERR_FILENO, " next_ch=");
+      if(debug_ptr_readable(next_ptr)) {
+        char next_ch = *next_ptr;
+        if(next_ch == '\n') {
+          write_str(STDERR_FILENO, "\\n");
+        } else if(next_ch == '\r') {
+          write_str(STDERR_FILENO, "\\r");
+        } else {
+          char buf[2] = { next_ch, '\0' };
+          write_str(STDERR_FILENO, buf);
+        }
+      } else {
+        write_str(STDERR_FILENO, "<invalid>");
+      }
+      write_str(STDERR_FILENO, "\n");
+
+      if(!debug_ptr_readable(cursor) || !debug_ptr_readable(next_ptr)) {
+        write_str(STDERR_FILENO, "[mosh] dollar guard treating literal due to invalid pointer\n");
         if(out_index + 1 >= capacity) {
           return false;
         }
         output[out_index++] = '$';
+        cursor++;
         continue;
       }
 
-      char name[MOSH_MAX_VAR_NAME];
-      size_t name_len = 0;
-      if(input[i] == '{') {
-        size_t start = ++i;
-        while(input[i] != '\0' && input[i] != '}' && name_len + 1 < sizeof(name)) {
-          name[name_len++] = input[i++];
-        }
-        if(input[i] == '}') {
-          // matched closing brace, proceed normally.
-        } else {
-          // Unmatched brace, treat as literal.
-          if(out_index + 1 >= capacity) {
-            return false;
-          }
-          output[out_index++] = '$';
-          i = start - 1;
-          continue;
-        }
-      } else {
-        size_t start = i;
-        if(shell_is_digit(input[i])) {
-          while(shell_is_digit(input[i]) && name_len + 1 < sizeof(name)) {
-            name[name_len++] = input[i++];
-          }
-        } else if(shell_is_ident_start(input[i])) {
-          while(shell_is_ident_char(input[i]) && name_len + 1 < sizeof(name)) {
-            name[name_len++] = input[i++];
-          }
-        }
-        i--;
-        if(name_len == 0) {
-          if(out_index + 1 >= capacity) {
-            return false;
-          }
-          output[out_index++] = '$';
-          continue;
-        }
-      }
-
-      name[name_len] = '\0';
-      const char* value = shell_var_get(name);
-      if(value == NULL) {
-        value = "";
-      }
-      if(!shell_append_text(output, capacity, &out_index, value)) {
+      debug_log_expand_dollar(cursor);
+      if(!shell_expand_dollar(&cursor, output, capacity, &out_index)) {
         return false;
       }
       continue;
     }
 
-    if(ch == '\\' && input[i + 1] != '\0') {
-      ch = input[++i];
+    if(ch == '\\' && cursor[1] != '\0') {
+      cursor++;
+      ch = *cursor;
     }
 
     if(out_index + 1 >= capacity) {
       return false;
     }
     output[out_index++] = ch;
+    cursor++;
   }
 
   if(out_index >= capacity) {
@@ -4466,6 +4623,197 @@ static bool contains_slash(const char* text) {
   return false;
 }
 
+static size_t format_hex_uintptr(uintptr_t value, char* out, size_t capacity) {
+  if(out == NULL || capacity == 0) {
+    return 0;
+  }
+  if(capacity < 3) {
+    out[0] = '\0';
+    return 0;
+  }
+
+  static const char hex_digits[] = "0123456789abcdef";
+  size_t len = 0;
+  out[len++] = '0';
+  if(len < capacity) {
+    out[len++] = 'x';
+  }
+
+  bool started = false;
+  for(int shift = (int)(sizeof(uintptr_t) * 8 - 4); shift >= 0; shift -= 4) {
+    uint8_t nibble = (uint8_t)((value >> shift) & 0xfu);
+    if(!started && nibble == 0 && shift != 0) {
+      continue;
+    }
+    started = true;
+    if(len + 1 >= capacity) {
+      break;
+    }
+    out[len++] = hex_digits[nibble];
+  }
+
+  if(!started) {
+    if(len + 1 < capacity) {
+      out[len++] = '0';
+    }
+  }
+
+  if(len < capacity) {
+    out[len] = '\0';
+  } else {
+    out[capacity - 1] = '\0';
+    len = capacity - 1;
+  }
+  return len;
+}
+
+static size_t format_signed_long(long value, char* out, size_t capacity) {
+  if(out == NULL || capacity == 0) {
+    return 0;
+  }
+
+  size_t index = 0;
+  unsigned long magnitude;
+  if(value < 0) {
+    if(index + 1 >= capacity) {
+      out[0] = '\0';
+      return 0;
+    }
+    out[index++] = '-';
+    magnitude = (unsigned long)(-value);
+  } else {
+    magnitude = (unsigned long)value;
+  }
+
+  size_t written = format_unsigned_value((size_t)magnitude, &out[index], capacity - index);
+  return index + written;
+}
+
+static void debug_write_ptr(int fd, const void* ptr) {
+  char buf[2 + sizeof(uintptr_t) * 2 + 1];
+  format_hex_uintptr((uintptr_t)ptr, buf, sizeof(buf));
+  write_str(fd, buf);
+}
+
+static void debug_write_long_field(int fd, const char* label, long value) {
+  if(label != NULL) {
+    write_str(fd, label);
+  }
+  char buf[32];
+  format_signed_long(value, buf, sizeof(buf));
+  write_str(fd, buf);
+}
+
+static void debug_write_int_field(int fd, const char* label, int value) {
+  if(label != NULL) {
+    write_str(fd, label);
+  }
+  char buf[16];
+  format_signed_value(value, buf, sizeof(buf));
+  write_str(fd, buf);
+}
+
+static void debug_log_exec_attempt(const char* stage,
+                                   const char* path,
+                                   char* const* argv,
+                                   char* const* envp) {
+  write_str(STDERR_FILENO, "[mosh] exec attempt stage=");
+  write_str(STDERR_FILENO, (stage != NULL) ? stage : "?");
+  write_str(STDERR_FILENO, " path_ptr=");
+  debug_write_ptr(STDERR_FILENO, path);
+  write_str(STDERR_FILENO, " argv=");
+  debug_write_ptr(STDERR_FILENO, argv);
+  write_str(STDERR_FILENO, " argv0=");
+  debug_write_ptr(STDERR_FILENO, (argv != NULL) ? argv[0] : NULL);
+  write_str(STDERR_FILENO, " envp=");
+  debug_write_ptr(STDERR_FILENO, envp);
+  write_str(STDERR_FILENO, " env0=");
+  debug_write_ptr(STDERR_FILENO, (envp != NULL && envp[0] != NULL) ? envp[0] : NULL);
+  write_str(STDERR_FILENO, "\n");
+}
+
+static void debug_log_exec_result(const char* stage,
+                                  const char* path,
+                                  long rc) {
+  write_str(STDERR_FILENO, "[mosh] exec result stage=");
+  write_str(STDERR_FILENO, (stage != NULL) ? stage : "?");
+  write_str(STDERR_FILENO, " path_ptr=");
+  debug_write_ptr(STDERR_FILENO, path);
+  write_str(STDERR_FILENO, " rc=");
+  debug_write_long_field(STDERR_FILENO, NULL, rc);
+  write_str(STDERR_FILENO, " errno=");
+  debug_write_int_field(STDERR_FILENO, NULL, errno);
+  write_str(STDERR_FILENO, "\n");
+}
+
+static void debug_log_expand_start(const char* input, char* output, size_t capacity) {
+  write_str(STDERR_FILENO, "[mosh] expand start input=");
+  debug_write_ptr(STDERR_FILENO, input);
+  write_str(STDERR_FILENO, " output=");
+  debug_write_ptr(STDERR_FILENO, output);
+  write_str(STDERR_FILENO, " cap=");
+  char buf[32];
+  format_unsigned_value(capacity, buf, sizeof(buf));
+  write_str(STDERR_FILENO, buf);
+  write_str(STDERR_FILENO, " input_text=");
+  if(input != NULL) {
+    if(debug_ptr_readable(input)) {
+      write_bytes(STDERR_FILENO, input, str_len(input));
+    } else {
+      write_str(STDERR_FILENO, "<invalid>");
+    }
+  } else {
+    write_str(STDERR_FILENO, "(null)");
+  }
+  write_str(STDERR_FILENO, "\n");
+  debug_dump_bytes("[mosh] expand input", input);
+}
+
+static void debug_log_expand_dollar(const char* cursor) {
+  write_str(STDERR_FILENO, "[mosh] expand dollar cursor=");
+  debug_write_ptr(STDERR_FILENO, cursor);
+  write_str(STDERR_FILENO, " values=");
+  if(cursor != NULL) {
+    if(debug_ptr_readable(cursor)) {
+      write_bytes(STDERR_FILENO, cursor, str_len(cursor));
+    } else {
+      write_str(STDERR_FILENO, "<invalid>");
+    }
+  }
+  write_str(STDERR_FILENO, "\n");
+  debug_dump_bytes("[mosh] expand dollar bytes", cursor);
+}
+
+static void debug_dump_bytes(const char* label, const char* data) {
+  write_str(STDERR_FILENO, label);
+  if(data == NULL) {
+    write_str(STDERR_FILENO, "(null)\n");
+    return;
+  }
+  write_str(STDERR_FILENO, " bytes=");
+  if(debug_ptr_readable(data)) {
+    const unsigned char* bytes = (const unsigned char*)data;
+    for(size_t idx = 0; idx < 64 && bytes[idx] != '\0'; idx++) {
+      char buf[4];
+      buf[0] = "0123456789abcdef"[(bytes[idx] >> 4) & 0xf];
+      buf[1] = "0123456789abcdef"[bytes[idx] & 0xf];
+      buf[2] = ' ';
+      buf[3] = '\0';
+      write_str(STDERR_FILENO, buf);
+    }
+  } else {
+    write_str(STDERR_FILENO, "<invalid>");
+  }
+  write_str(STDERR_FILENO, "\n");
+}
+
+static bool debug_ptr_readable(const void* ptr) {
+  uintptr_t value = (uintptr_t)ptr;
+  const uintptr_t MIN_USER_PTR = 0x1000u;
+  const uintptr_t MAX_USER_PTR = 0x00007fffffffffffULL;
+  return value >= MIN_USER_PTR && value <= MAX_USER_PTR;
+}
+
 static void exec_command(char** argv, size_t argc) {
   if(argv == NULL || argc == 0 || argv[0] == NULL) {
     _exit(0);
@@ -4476,7 +4824,9 @@ static void exec_command(char** argv, size_t argc) {
   const char* command = argv[0];
 
   if(contains_slash(command)) {
+    debug_log_exec_attempt("direct", command, argv, envp);
     long rc = mosh_execve(command, argv, envp);
+    debug_log_exec_result("direct", command, rc);
     if(rc < 0) {
       write_str(STDERR_FILENO, "mosh: exec failed\n");
       _exit(126);
@@ -4501,7 +4851,9 @@ static void exec_command(char** argv, size_t argc) {
     bool at_end = (segment[segment_len] == '\0');
 
     if(segment_len == 0) {
+      debug_log_exec_attempt("empty_path", command, argv, envp);
       long rc = mosh_execve(command, argv, envp);
+      debug_log_exec_result("empty_path", command, rc);
       if(rc >= 0) {
         return;
       }
@@ -4520,7 +4872,9 @@ static void exec_command(char** argv, size_t argc) {
           candidate[pos++] = command[i];
         }
         candidate[pos] = '\0';
+        debug_log_exec_attempt("path", candidate, argv, envp);
         long rc = mosh_execve(candidate, argv, envp);
+        debug_log_exec_result("path", candidate, rc);
         if(rc >= 0) {
           return;
         }
@@ -4676,14 +5030,19 @@ static int launch_command(char* line) {
       shell_starts_with_keyword(trimmed_raw, "for") ||
       shell_starts_with_keyword(trimmed_raw, "function") ||
       shell_is_inline_function_signature(trimmed_raw))) {
-    char expanded_segment[MOSH_MAX_FUNCTION_BODY];
-    if(!shell_expand_variables(trimmed_raw, expanded_segment, sizeof(expanded_segment))) {
-      write_str(STDOUT_FILENO, "mosh: expansion too long\n");
-      shell_set_status_code(1);
-      return encode_raw_status_from_code(shell_last_status);
-    }
     char working_segment[MOSH_MAX_FUNCTION_BODY];
-    str_copy(working_segment, sizeof(working_segment), expanded_segment);
+    if(strchr(trimmed_raw, '$') != NULL) {
+      char expanded_segment[MOSH_MAX_FUNCTION_BODY];
+      write_str(STDERR_FILENO, "[mosh] expand ctx=launch_command:trimmed\n");
+      if(!shell_expand_variables(trimmed_raw, expanded_segment, sizeof(expanded_segment))) {
+        write_str(STDOUT_FILENO, "mosh: expansion too long\n");
+        shell_set_status_code(1);
+        return encode_raw_status_from_code(shell_last_status);
+      }
+      str_copy(working_segment, sizeof(working_segment), expanded_segment);
+    } else {
+      str_copy(working_segment, sizeof(working_segment), trimmed_raw);
+    }
     int builtin_status = 0;
     if(handle_builtin(trimmed_raw, working_segment, &builtin_status)) {
       return builtin_status;
@@ -4709,15 +5068,28 @@ static int launch_command(char* line) {
       return encode_raw_status_from_code(shell_last_status);
     }
 
-    char expanded_segment[MOSH_MAX_FUNCTION_BODY];
-    if(!shell_expand_variables(raw_segment, expanded_segment, sizeof(expanded_segment))) {
-      write_str(STDOUT_FILENO, "mosh: expansion too long\n");
-      shell_set_status_code(1);
-      return encode_raw_status_from_code(shell_last_status);
+    write_str(STDERR_FILENO, "[mosh] segment raw=");
+    if(debug_ptr_readable(raw_segment)) {
+      write_bytes(STDERR_FILENO, raw_segment, str_len(raw_segment));
+    } else {
+      write_str(STDERR_FILENO, "<invalid>");
     }
+    write_str(STDERR_FILENO, "\n");
+    debug_dump_bytes("[mosh] segment raw", raw_segment);
 
     char working_segment[MOSH_MAX_FUNCTION_BODY];
-    str_copy(working_segment, sizeof(working_segment), expanded_segment);
+    if(strchr(raw_segment, '$') != NULL) {
+      write_str(STDERR_FILENO, "[mosh] expand ctx=launch_command:segment\n");
+      char expanded_segment[MOSH_MAX_FUNCTION_BODY];
+      if(!shell_expand_variables(raw_segment, expanded_segment, sizeof(expanded_segment))) {
+        write_str(STDOUT_FILENO, "mosh: expansion too long\n");
+        shell_set_status_code(1);
+        return encode_raw_status_from_code(shell_last_status);
+      }
+      str_copy(working_segment, sizeof(working_segment), expanded_segment);
+    } else {
+      str_copy(working_segment, sizeof(working_segment), raw_segment);
+    }
 
     int builtin_status = 0;
     if(handle_builtin(raw_segment, working_segment, &builtin_status)) {

--- a/include/kernel/context_switch.h
+++ b/include/kernel/context_switch.h
@@ -1,0 +1,8 @@
+#ifndef KERNEL_CONTEXT_SWITCH_H
+#define KERNEL_CONTEXT_SWITCH_H
+
+#include <stdint.h>
+
+void context_switch(uint64_t* prev_rsp, uint64_t next_rsp);
+
+#endif

--- a/include/kernel/proc.h
+++ b/include/kernel/proc.h
@@ -138,6 +138,7 @@ typedef struct proc_info_t {
   proc_info_p  first_child;
   proc_info_p  sibling_next;
   cpu_state_t* cpu_state;
+  uint64_t     kernel_rsp;
   void*        stack_pointer;
   uintptr_t*   stack_base;
   virt_addr_t  user_stack_base_vaddr;
@@ -172,7 +173,7 @@ void proc_create(proc_info_p proc, const char* name, void (*entrypoint)(void *),
 void proc_execute(proc_info_p proc);
 void proc_exit(int code);
 void proc_exit_signal(int signo);
-void proc_switch(void* state);
+cpu_state_p proc_switch(cpu_state_p state);
 void proc_create_user(proc_info_p proc, const char* name, const void* code_blob, size_t code_size, void* arg);
 bool proc_register_user_segment(proc_info_p proc, phys_addr_t phys, size_t pages);
 void proc_unregister_user_segment(proc_info_p proc, phys_addr_t phys, size_t pages);

--- a/include/kernel/proc.h
+++ b/include/kernel/proc.h
@@ -160,6 +160,8 @@ typedef struct proc_info_t {
   bool         stopped;
   bool         stop_status_pending;
   bool         continued_pending;
+  bool         syscall_gs_active;
+  bool         syscall_gs_needs_restore;
 } proc_info_t;
 
 typedef proc_info_t* proc_info_p;

--- a/src/kernel/arch/x86_64/context_switch.S
+++ b/src/kernel/arch/x86_64/context_switch.S
@@ -1,0 +1,7 @@
+    .text
+    .globl context_switch
+    .type context_switch, @function
+context_switch:
+    movq %rsp, (%rdi)
+    movq %rsi, %rsp
+    ret

--- a/src/kernel/arch/x86_64/proc_entry.S
+++ b/src/kernel/arch/x86_64/proc_entry.S
@@ -1,0 +1,21 @@
+    .text
+    .globl proc_enter_userspace
+    .type proc_enter_userspace, @function
+proc_enter_userspace:
+    mov %rdi, %rsp
+    pop %r15
+    pop %r14
+    pop %r13
+    pop %r12
+    pop %r11
+    pop %r10
+    pop %r9
+    pop %r8
+    pop %rdi
+    pop %rsi
+    pop %rbp
+    pop %rdx
+    pop %rcx
+    pop %rbx
+    pop %rax
+    iretq

--- a/src/kernel/idt.c
+++ b/src/kernel/idt.c
@@ -191,6 +191,12 @@ void idt_pf_isr_handler(idt_exception_p cpu_state) {
                   info.present ? "yes" : "no",
                   info.write ? "yes" : "no",
                   current->pid);
+    exception_log("    rip=0x%016lx cs=0x%04lx rflags=0x%016lx rsp=0x%016lx ss=0x%04lx\n",
+                  fault_rip,
+                  fault_cs,
+                  fault_rflags,
+                  fault_rsp,
+                  privilege_transition ? (uint64_t)fault_ss : (uint64_t)ss);
     proc_exit_signal(SIGSEGV);
     return;
   }

--- a/src/kernel/proc/proc.c
+++ b/src/kernel/proc/proc.c
@@ -23,6 +23,11 @@
 uint64_t last_pid = 0;
 static uint64_t last_exec = 0;
 
+static void __attribute__((noreturn)) proc_first_entry(void);
+static void proc_prepare_switch_frame(proc_info_p proc);
+
+extern void proc_enter_userspace(syscall_frame_t* frame) __attribute__((noreturn));
+
 proc_info_t kernel_process_info = {
   .first_child = NULL,
   .sibling_next = NULL,
@@ -65,6 +70,62 @@ typedef struct scheduler_queue_t {
 static scheduler_queue_t ready_queues[PROC_PRIORITY_COUNT];
 static proc_info_p sleep_queue_head = NULL;
 static uint32_t scheduler_actions = 0;
+
+static void scheduler_timer_callback(void* arg) {
+  (void)proc_switch((cpu_state_p)arg);
+}
+
+static void proc_prepare_switch_frame(proc_info_p proc) {
+  if(proc == NULL || proc->stack_base == NULL) {
+    if(proc != NULL) {
+      proc->cpu_state = NULL;
+      proc->kernel_rsp = 0;
+    }
+    return;
+  }
+
+  uint8_t* top = (uint8_t*)proc->stack_base + PROC_STACK_SIZE;
+  top -= sizeof(syscall_frame_t);
+  proc->cpu_state = (cpu_state_t*)top;
+  memset(proc->cpu_state, 0, sizeof(cpu_state_t));
+
+  top -= sizeof(uint64_t);
+  *((uint64_t*)top) = (uint64_t)proc_first_entry;
+  proc->kernel_rsp = (uint64_t)top;
+}
+
+static void __attribute__((noreturn)) proc_first_entry(void) {
+  proc_info_p proc = current;
+  if(proc == NULL) {
+    halt();
+  }
+
+  if(!proc->user_mode) {
+    uint64_t kernel_sp = (uint64_t)((uint8_t*)proc->stack_base + PROC_STACK_SIZE);
+    kernel_sp -= 8; // SysV ABI: align before call so callee sees 16-byte alignment
+    __asm__ volatile("mov %0, %%rsp" :: "r"(kernel_sp) : "rsp");
+    proc = current;
+  }
+
+  enable_interrupts();
+
+  if(proc->user_mode) {
+    syscall_frame_t* frame = (syscall_frame_t*)proc->cpu_state;
+    if(frame == NULL) {
+      halt();
+    }
+    proc_enter_userspace(frame);
+  }
+
+  void (*entrypoint)(void*) = proc->entrypoint;
+  void* arg = proc->arguments;
+  if(entrypoint != NULL) {
+    entrypoint(arg);
+  }
+
+  proc_exit(0);
+  halt();
+}
 
 static inline int encode_stopped_status(int signo) {
   return ((signo & 0x7f) << 8) | 0x7f;
@@ -379,8 +440,19 @@ cpu_state_p proc_switch(cpu_state_p frame) {
   }
 
   if(current && current->cpu_state) {
+    serial_printf("proc_switch: memcpy save pid=%u frame=%p dest=%p size=%zu\n",
+                  current->pid,
+                  (void*)frame,
+                  (void*)current->cpu_state,
+                  sizeof(cpu_state_t));
+    serial_printf("proc_switch: frame values rip=%lx rsp=%lx rdi=%lx rsi=%lx rdx=%lx rcx=%lx\n",
+                  ((cpu_state_t*)frame)->rip,
+                  ((cpu_state_t*)frame)->rsp,
+                  ((cpu_state_t*)frame)->rdi,
+                  ((cpu_state_t*)frame)->rsi,
+                  ((cpu_state_t*)frame)->rdx,
+                  ((cpu_state_t*)frame)->rcx);
     memcpy(current->cpu_state, frame, sizeof(cpu_state_t));
-    current->kernel_rsp = (uint64_t)frame;
   }
 
   scheduler_wake_sleepers(now);
@@ -411,6 +483,13 @@ cpu_state_p proc_switch(cpu_state_p frame) {
   }
 
   proc_info_p previous = current;
+
+  if(previous != NULL &&
+     previous->syscall_gs_active &&
+     !previous->syscall_gs_needs_restore) {
+    __asm__ volatile("swapgs" ::: "memory");
+    previous->syscall_gs_needs_restore = true;
+  }
 
   if(previous != NULL) {
     if(to_sleep) {
@@ -482,6 +561,11 @@ cpu_state_p proc_switch(cpu_state_p frame) {
   current->time_slice_remaining_us = current->quantum_us;
   current->last_dispatch_us = now;
 
+  if(current->syscall_gs_needs_restore) {
+    __asm__ volatile("swapgs" ::: "memory");
+    current->syscall_gs_needs_restore = false;
+  }
+
   phys_addr_t desired_cr3 = current->address_space_root ? current->address_space_root : pmm_get_kernel_cr3();
   if(read_cr3() != desired_cr3) {
     write_cr3(desired_cr3);
@@ -490,7 +574,14 @@ cpu_state_p proc_switch(cpu_state_p frame) {
   serial_printf("proc_switch: restore pid=%u cpu_state->rax=%lx\n",
                 current->pid,
                 current->cpu_state->rax);
-  serial_printf("proc_switch: resume frame=%p\n", (void*)current->cpu_state);
+  serial_printf("proc_switch: resume frame=%p rip=%lx rsp=%lx rdi=%lx rsi=%lx rdx=%lx rcx=%lx\n",
+                (void*)current->cpu_state,
+                current->cpu_state->rip,
+                current->cpu_state->rsp,
+                current->cpu_state->rdi,
+                current->cpu_state->rsi,
+                current->cpu_state->rdx,
+                current->cpu_state->rcx);
 
   uint64_t kernel_stack = proc_kernel_stack_top(current);
   if(kernel_stack != 0) {
@@ -499,9 +590,11 @@ cpu_state_p proc_switch(cpu_state_p frame) {
   }
 
   cpu_state_p next_frame = current->cpu_state;
-  uint64_t next_rsp = current->kernel_rsp ? current->kernel_rsp : (uint64_t)next_frame;
-  uint64_t dummy_prev = (uint64_t)frame;
-  uint64_t* prev_slot = previous ? &previous->kernel_rsp : &dummy_prev;
+  uint64_t next_rsp = current->kernel_rsp;
+  if(next_rsp == 0) {
+    next_rsp = (uint64_t)next_frame;
+  }
+  uint64_t* prev_slot = previous ? &previous->kernel_rsp : &next_rsp;
   context_switch(prev_slot, next_rsp);
   return next_frame;
 }
@@ -559,10 +652,9 @@ void proc_create(proc_info_p proc, const char* name, void (*entrypoint)(void *),
   proc->last_dispatch_us = 0;
   proc->waitpid_target = -1;
   proc->waitpid_waiting = false;
-
-  proc->cpu_state = (cpu_state_t*)((uint8_t*)proc->stack_base + PROC_STACK_SIZE - sizeof(cpu_state_t));
-  memset(proc->cpu_state, 0, sizeof(cpu_state_t));
-  proc->kernel_rsp = (uint64_t)proc->cpu_state;
+  proc->syscall_gs_active = false;
+  proc->syscall_gs_needs_restore = false;
+  proc_prepare_switch_frame(proc);
   proc->cpu_state->rip = (uint64_t)entrypoint;
   proc->cpu_state->rdi = (uint64_t)arg;
   proc->cpu_state->rsp = (uint64_t)proc->stack_base + PROC_STACK_SIZE;
@@ -1074,9 +1166,7 @@ proc_info_p proc_fork(proc_info_p parent, const syscall_frame_t* frame, int* err
   memset(child->stack_base, 0, PROC_STACK_SIZE);
   serial_printf("proc_fork: stack allocated aligned=%p\n", child->stack_base);
 
-  child->cpu_state = (cpu_state_t*)((uint8_t*)child->stack_base + PROC_STACK_SIZE - sizeof(cpu_state_t));
-  memset(child->cpu_state, 0, sizeof(cpu_state_t));
-  child->kernel_rsp = (uint64_t)child->cpu_state;
+  proc_prepare_switch_frame(child);
   serial_printf("proc_fork: cpu_state allocated\n");
 
   phys_addr_t new_root = pmm_clone_kernel_address_space();
@@ -1699,6 +1789,7 @@ void scheduler_init() {
     }
   }
   memset(current->cpu_state, 0, sizeof(cpu_state_t));
+  current->kernel_rsp = (uint64_t)current->cpu_state;
 
   current->pid = last_pid++;
   current->address_space_root = pmm_get_kernel_cr3();
@@ -1712,7 +1803,7 @@ void scheduler_init() {
     tss_update_kernel_stack(kernel_stack);
     syscall_set_kernel_stack(kernel_stack);
   }
-  register_timer_callback(proc_switch);
+  register_timer_callback(scheduler_timer_callback);
   printf(".OK\n");
 }
 

--- a/src/kernel/proc/proc.c
+++ b/src/kernel/proc/proc.c
@@ -20,6 +20,16 @@
 #include <string.h>
 #include <types.h>
 
+#ifndef CONFIG_DEBUG_SCHEDULER
+#define CONFIG_DEBUG_SCHEDULER 0
+#endif
+
+#if CONFIG_DEBUG_SCHEDULER
+#define SCHED_TRACE(...) serial_printf(__VA_ARGS__)
+#else
+#define SCHED_TRACE(...) ((void)0)
+#endif
+
 uint64_t last_pid = 0;
 static uint64_t last_exec = 0;
 
@@ -188,10 +198,10 @@ static void proc_link_child(proc_info_p parent, proc_info_p child) {
   child->sibling_next = parent->first_child;
   parent->first_child = child;
   parent->children_count++;
-  serial_printf("proc: parent=%s(pid=%u) forked child pid=%u\n",
-                parent->name,
-                parent->pid,
-                child->pid);
+  SCHED_TRACE("proc: parent=%s(pid=%u) forked child pid=%u\n",
+              parent->name,
+              parent->pid,
+              child->pid);
 }
 
 #define SCHED_ACTION_FORCE (1u << 0)
@@ -408,11 +418,11 @@ static void scheduler_cleanup_process(proc_info_p proc) {
 }
 
 void proc_debug(cpu_state_p state) {
-  serial_printf("proc_debug: %p\n", state);
-  serial_printf("            cs:  %lx ss:  %lx rfl: %lx\n", state->cs, state->ss, state->rflags);
-  serial_printf("proc_debug: rbp: %lx rdi: %lx rip: %lx rsi: %lx\n", state->rbp, state->rdi, state->rip, state->rsi);
-  serial_printf("proc_debug: rsp: %lx rax: %lx rbx: %lx rcx: %lx\n", state->rsp, state->rax, state->rbx, state->rcx);
-  serial_printf("proc_debug: rdx: %lx r8:  %lx r9:  %lx r10: %lx\n", state->rdx, state->r8, state->r9, state->r10);
+  SCHED_TRACE("proc_debug: %p\n", state);
+  SCHED_TRACE("            cs:  %lx ss:  %lx rfl: %lx\n", state->cs, state->ss, state->rflags);
+  SCHED_TRACE("proc_debug: rbp: %lx rdi: %lx rip: %lx rsi: %lx\n", state->rbp, state->rdi, state->rip, state->rsi);
+  SCHED_TRACE("proc_debug: rsp: %lx rax: %lx rbx: %lx rcx: %lx\n", state->rsp, state->rax, state->rbx, state->rcx);
+  SCHED_TRACE("proc_debug: rdx: %lx r8:  %lx r9:  %lx r10: %lx\n", state->rdx, state->r8, state->r9, state->r10);
 }
 
 cpu_state_p proc_switch(cpu_state_p frame) {
@@ -431,27 +441,27 @@ cpu_state_p proc_switch(cpu_state_p frame) {
 
   if(current != NULL) {
     if(current->cpu_state != NULL) {
-  serial_printf("proc_switch: save pid=%u prev_rax=%lx frame->rax=%lx\n",
-                current->pid,
-                current->cpu_state ? current->cpu_state->rax : 0xffffffffffffffffull,
-                ((cpu_state_t*)frame)->rax);
+      SCHED_TRACE("proc_switch: save pid=%u prev_rax=%lx frame->rax=%lx\n",
+                  current->pid,
+                  current->cpu_state ? current->cpu_state->rax : 0xffffffffffffffffull,
+                  ((cpu_state_t*)frame)->rax);
     }
     proc_signal_handle_pending(current, frame);
   }
 
   if(current && current->cpu_state) {
-    serial_printf("proc_switch: memcpy save pid=%u frame=%p dest=%p size=%zu\n",
-                  current->pid,
-                  (void*)frame,
-                  (void*)current->cpu_state,
-                  sizeof(cpu_state_t));
-    serial_printf("proc_switch: frame values rip=%lx rsp=%lx rdi=%lx rsi=%lx rdx=%lx rcx=%lx\n",
-                  ((cpu_state_t*)frame)->rip,
-                  ((cpu_state_t*)frame)->rsp,
-                  ((cpu_state_t*)frame)->rdi,
-                  ((cpu_state_t*)frame)->rsi,
-                  ((cpu_state_t*)frame)->rdx,
-                  ((cpu_state_t*)frame)->rcx);
+    SCHED_TRACE("proc_switch: memcpy save pid=%u frame=%p dest=%p size=%zu\n",
+                current->pid,
+                (void*)frame,
+                (void*)current->cpu_state,
+                sizeof(cpu_state_t));
+    SCHED_TRACE("proc_switch: frame values rip=%lx rsp=%lx rdi=%lx rsi=%lx rdx=%lx rcx=%lx\n",
+                ((cpu_state_t*)frame)->rip,
+                ((cpu_state_t*)frame)->rsp,
+                ((cpu_state_t*)frame)->rdi,
+                ((cpu_state_t*)frame)->rsi,
+                ((cpu_state_t*)frame)->rdx,
+                ((cpu_state_t*)frame)->rcx);
     memcpy(current->cpu_state, frame, sizeof(cpu_state_t));
   }
 
@@ -571,17 +581,17 @@ cpu_state_p proc_switch(cpu_state_p frame) {
     write_cr3(desired_cr3);
   }
 
-  serial_printf("proc_switch: restore pid=%u cpu_state->rax=%lx\n",
-                current->pid,
-                current->cpu_state->rax);
-  serial_printf("proc_switch: resume frame=%p rip=%lx rsp=%lx rdi=%lx rsi=%lx rdx=%lx rcx=%lx\n",
-                (void*)current->cpu_state,
-                current->cpu_state->rip,
-                current->cpu_state->rsp,
-                current->cpu_state->rdi,
-                current->cpu_state->rsi,
-                current->cpu_state->rdx,
-                current->cpu_state->rcx);
+  SCHED_TRACE("proc_switch: restore pid=%u cpu_state->rax=%lx\n",
+              current->pid,
+              current->cpu_state->rax);
+  SCHED_TRACE("proc_switch: resume frame=%p rip=%lx rsp=%lx rdi=%lx rsi=%lx rdx=%lx rcx=%lx\n",
+              (void*)current->cpu_state,
+              current->cpu_state->rip,
+              current->cpu_state->rsp,
+              current->cpu_state->rdi,
+              current->cpu_state->rsi,
+              current->cpu_state->rdx,
+              current->cpu_state->rcx);
 
   uint64_t kernel_stack = proc_kernel_stack_top(current);
   if(kernel_stack != 0) {
@@ -616,7 +626,7 @@ void proc_create(proc_info_p proc, const char* name, void (*entrypoint)(void *),
   proc->stop_status_pending = false;
   proc->stop_status = 0;
 
-  serial_printf("proc_create: Creating process %s - %s with arg %lx\n", name, proc->name, arg);
+  SCHED_TRACE("proc_create: Creating process %s - %s with arg %lx\n", name, proc->name, arg);
 
   // ensure the stack is aligned to a 16-byte boundary
   proc->stack_pointer = kmalloc(PROC_STACK_SIZE + 0xF);
@@ -627,7 +637,7 @@ void proc_create(proc_info_p proc, const char* name, void (*entrypoint)(void *),
   uintptr_t aligned = ((uintptr_t)proc->stack_pointer + 0xF) & ~((uintptr_t)0xF);
   proc->stack_base = (uintptr_t*)aligned;
   memset(proc->stack_base, 0, PROC_STACK_SIZE);
-  serial_printf("proc_create: entrypoint @ %p, args @ %p\n", entrypoint, arg);
+  SCHED_TRACE("proc_create: entrypoint @ %p, args @ %p\n", entrypoint, arg);
   proc->state = PROC_STATE_NEW;
   proc->entrypoint = entrypoint;
   proc->arguments = arg;
@@ -1014,11 +1024,11 @@ void proc_request_sleep(uint64_t duration_us) {
   current->sleep_until = scheduler_now_us() + duration_us;
   current->time_slice_remaining_us = 0;
   scheduler_actions |= (SCHED_ACTION_SLEEP | SCHED_ACTION_FORCE);
-  serial_printf("proc_request_sleep: pid=%u duration=%lu\n",
-                current->pid,
-                (unsigned long)duration_us);
-  serial_printf("proc_request_sleep: caller=%lx\n",
-                (unsigned long)__builtin_return_address(0));
+  SCHED_TRACE("proc_request_sleep: pid=%u duration=%lu\n",
+              current->pid,
+              (unsigned long)duration_us);
+  SCHED_TRACE("proc_request_sleep: caller=%lx\n",
+              (unsigned long)__builtin_return_address(0));
 }
 
 void proc_request_block(void) {
@@ -1122,7 +1132,7 @@ proc_info_p proc_fork(proc_info_p parent, const syscall_frame_t* frame, int* err
     return NULL;
   }
 
-  serial_printf("proc_fork: parent pid=%u entering\n", parent->pid);
+  SCHED_TRACE("proc_fork: parent pid=%u entering\n", parent->pid);
   proc_info_p child = kmalloc(sizeof(proc_info_t));
   if(child == NULL) {
     serial_printf("proc_fork: kmalloc proc_info failed\n");
@@ -1132,7 +1142,7 @@ proc_info_p proc_fork(proc_info_p parent, const syscall_frame_t* frame, int* err
   proc_file_table_init(child);
   proc_file_table_clone(child, parent);
   proc_signal_state_copy(child, parent);
-  serial_printf("proc_fork: proc_info allocated\n");
+  SCHED_TRACE("proc_fork: proc_info allocated\n");
 
   child->parent = parent;
   child->pid = last_pid++;
@@ -1164,10 +1174,10 @@ proc_info_p proc_fork(proc_info_p parent, const syscall_frame_t* frame, int* err
   uintptr_t aligned = ((uintptr_t)child->stack_pointer + 0xF) & ~((uintptr_t)0xF);
   child->stack_base = (uintptr_t*)aligned;
   memset(child->stack_base, 0, PROC_STACK_SIZE);
-  serial_printf("proc_fork: stack allocated aligned=%p\n", child->stack_base);
+  SCHED_TRACE("proc_fork: stack allocated aligned=%p\n", child->stack_base);
 
   proc_prepare_switch_frame(child);
-  serial_printf("proc_fork: cpu_state allocated\n");
+  SCHED_TRACE("proc_fork: cpu_state allocated\n");
 
   phys_addr_t new_root = pmm_clone_kernel_address_space();
   if(new_root == 0) {
@@ -1176,7 +1186,7 @@ proc_info_p proc_fork(proc_info_p parent, const syscall_frame_t* frame, int* err
     return NULL;
   }
   child->address_space_root = new_root;
-  serial_printf("proc_fork: new address space=%lx\n", (unsigned long)new_root);
+  SCHED_TRACE("proc_fork: new address space=%lx\n", (unsigned long)new_root);
 
   child->user_segment_count = 0;
   child->shm_attachment_count = 0;
@@ -1187,7 +1197,7 @@ proc_info_p proc_fork(proc_info_p parent, const syscall_frame_t* frame, int* err
     proc_free_resources(child);
     return NULL;
   }
-  serial_printf("proc_fork: vm_clone complete\n");
+  SCHED_TRACE("proc_fork: vm_clone complete\n");
 
   if(!proc_shm_inherit(child, parent)) {
     serial_printf("proc_fork: shared memory inheritance failed\n");
@@ -1197,20 +1207,20 @@ proc_info_p proc_fork(proc_info_p parent, const syscall_frame_t* frame, int* err
 
   memcpy(child->cpu_state, frame, sizeof(syscall_frame_t));
   child->cpu_state->rax = 0;
-  serial_printf("proc_fork: child pid=%u rax=%lu rip=%lx\n",
-                child->pid,
-                child->cpu_state->rax,
-                child->cpu_state->rip);
+  SCHED_TRACE("proc_fork: child pid=%u rax=%lu rip=%lx\n",
+              child->pid,
+              child->cpu_state->rax,
+              child->cpu_state->rip);
 
   proc_set_priority(child, parent->priority);
   child->time_slice_remaining_us = child->quantum_us;
   child->state = PROC_STATE_READY;
 
   proc_link_child(parent, child);
-  serial_printf("proc_fork: linked child pid=%u\n", child->pid);
+  SCHED_TRACE("proc_fork: linked child pid=%u\n", child->pid);
 
   proc_execute(child);
-  serial_printf("proc_fork: scheduled child pid=%u\n", child->pid);
+  SCHED_TRACE("proc_fork: scheduled child pid=%u\n", child->pid);
 
   if(err_out) {
     *err_out = 0;
@@ -1232,7 +1242,7 @@ int proc_exec_image(proc_info_p proc,
     return -EINVAL;
   }
 
-  serial_printf("proc_exec_image: pid=%u size=%lu\n", proc->pid, (unsigned long)size);
+  SCHED_TRACE("proc_exec_image: pid=%u size=%lu\n", proc->pid, (unsigned long)size);
 
   uint8_t* elf_copy = kmalloc(size);
   if(elf_copy == NULL) {
@@ -1241,7 +1251,7 @@ int proc_exec_image(proc_info_p proc,
   }
 
   memcpy(elf_copy, image, size);
-  serial_printf("proc_exec_image: elf copied\n");
+  SCHED_TRACE("proc_exec_image: elf copied\n");
 
   phys_addr_t new_root = pmm_clone_kernel_address_space();
   if(new_root == 0) {
@@ -1249,7 +1259,7 @@ int proc_exec_image(proc_info_p proc,
     serial_printf("proc_exec_image: clone address space failed\n");
     return -ENOMEM;
   }
-  serial_printf("proc_exec_image: new_root=%lx\n", (unsigned long)new_root);
+  SCHED_TRACE("proc_exec_image: new_root=%lx\n", (unsigned long)new_root);
 
   proc_info_t* staging = kmalloc(sizeof(proc_info_t));
   if(staging == NULL) {
@@ -1264,7 +1274,7 @@ int proc_exec_image(proc_info_p proc,
   staging->address_space_root = new_root;
 
   proc_file_table_prepare_exec(proc);
-  serial_printf("proc_exec_image: file table prepared\n");
+  SCHED_TRACE("proc_exec_image: file table prepared\n");
 
   virt_addr_t stack_top = user_stack_top(proc->pid);
   virt_addr_t stack_base_vaddr = stack_top - PROC_USER_STACK_SIZE;
@@ -1281,7 +1291,7 @@ int proc_exec_image(proc_info_p proc,
     serial_printf("proc_exec_image: vm_region_add stack failed\n");
     goto fail;
   }
-  serial_printf("proc_exec_image: stack region added\n");
+  SCHED_TRACE("proc_exec_image: stack region added\n");
 
   vm_region_t* stack_region = vm_region_find(staging, stack_base_vaddr);
   if(stack_region == NULL) {
@@ -1293,7 +1303,7 @@ int proc_exec_image(proc_info_p proc,
     serial_printf("proc_exec_image: initial stack alloc failed\n");
     goto fail;
   }
-  serial_printf("proc_exec_image: initial stack phys=%lx\n", (unsigned long)initial_stack_phys);
+  SCHED_TRACE("proc_exec_image: initial stack phys=%lx\n", (unsigned long)initial_stack_phys);
 
   void* stack_page_ptr = (void*)physical_to_virtual(initial_stack_phys);
   memset(stack_page_ptr, 0, PAGE_SIZE);
@@ -1304,7 +1314,7 @@ int proc_exec_image(proc_info_p proc,
     serial_printf("proc_exec_image: map initial stack failed\n");
     goto fail;
   }
-  serial_printf("proc_exec_image: initial stack mapped\n");
+  SCHED_TRACE("proc_exec_image: initial stack mapped\n");
 
   if(!proc_register_user_segment(staging, initial_stack_phys, 1)) {
     pmm_unmap_page_in_root(new_root, initial_stack_page);
@@ -1312,7 +1322,7 @@ int proc_exec_image(proc_info_p proc,
     serial_printf("proc_exec_image: register stack segment failed\n");
     goto fail;
   }
-  serial_printf("proc_exec_image: stack segment registered\n");
+  SCHED_TRACE("proc_exec_image: stack segment registered\n");
 
   vm_region_note_mapping(stack_region, initial_stack_page, PAGE_SIZE);
 
@@ -1322,7 +1332,7 @@ int proc_exec_image(proc_info_p proc,
     result = -ENOEXEC;
     goto fail;
   }
-  serial_printf("proc_exec_image: elf loaded entry=%lx\n", entry);
+  SCHED_TRACE("proc_exec_image: elf loaded entry=%lx\n", entry);
 
   proc->brk = 0;
   proc->heap = 0;
@@ -1396,7 +1406,7 @@ int proc_exec_image(proc_info_p proc,
   }
 
   memcpy(proc->cpu_state, frame, sizeof(syscall_frame_t));
-  serial_printf("proc_exec_image: completed successfully\n");
+  SCHED_TRACE("proc_exec_image: completed successfully\n");
 
   kfree(staging);
 
@@ -1538,11 +1548,11 @@ static bool proc_setup_exec_stack(proc_info_p proc,
   frame->rdi = argc;
   frame->rsi = argv_user;
   frame->rdx = envp_user;
-  serial_printf("proc_setup_exec_stack: argc=%lu argv=%lx envp=%lx sp=%lx\n",
-                (unsigned long)argc,
-                (unsigned long)argv_user,
-                (unsigned long)envp_user,
-                (unsigned long)sp);
+  SCHED_TRACE("proc_setup_exec_stack: argc=%lu argv=%lx envp=%lx sp=%lx\n",
+              (unsigned long)argc,
+              (unsigned long)argv_user,
+              (unsigned long)envp_user,
+              (unsigned long)sp);
 
   if(argv_ptrs) {
     kfree(argv_ptrs);
@@ -1765,7 +1775,7 @@ void proc_execute(proc_info_p proc) {
   proc->time_slice_remaining_us = proc->quantum_us;
   proc->last_dispatch_us = 0;
   ready_queue_push(proc);
-  serial_printf("proc_execute: queued process %s (priority %u)\n", proc->name, proc->priority);
+  SCHED_TRACE("proc_execute: queued process %s (priority %u)\n", proc->name, proc->priority);
 }
 
 void scheduler_init() {
@@ -1821,7 +1831,7 @@ static void proc_exit_with_status(int status) {
   current->stopped = false;
   current->stop_status_pending = false;
   current->continued_pending = false;
-  serial_printf("proc_exit: Process %s exited with status %d\n", current->name, status);
+  SCHED_TRACE("proc_exit: Process %s exited with status %d\n", current->name, status);
 
   proc_info_p parent = current->parent;
   if(parent != NULL && parent->waitpid_waiting) {

--- a/src/kernel/proc/proc.c
+++ b/src/kernel/proc/proc.c
@@ -81,6 +81,38 @@ static scheduler_queue_t ready_queues[PROC_PRIORITY_COUNT];
 static proc_info_p sleep_queue_head = NULL;
 static uint32_t scheduler_actions = 0;
 
+static void proc_table_insert(proc_info_p proc) {
+  if(proc == NULL) {
+    return;
+  }
+
+  for(size_t i = 0; i < PROC_MAX; ++i) {
+    if(procs[i] == proc) {
+      return; // already registered
+    }
+    if(procs[i] == NULL) {
+      procs[i] = proc;
+      return;
+    }
+  }
+
+  serial_printf("proc_table_insert: no free slot for pid=%u\n", proc->pid);
+  halt();
+}
+
+static void proc_table_remove(proc_info_p proc) {
+  if(proc == NULL) {
+    return;
+  }
+
+  for(size_t i = 0; i < PROC_MAX; ++i) {
+    if(procs[i] == proc) {
+      procs[i] = NULL;
+      return;
+    }
+  }
+}
+
 static void scheduler_timer_callback(void* arg) {
   (void)proc_switch((cpu_state_p)arg);
 }
@@ -263,6 +295,8 @@ static void proc_free_resources(proc_info_p proc) {
     return;
   }
 
+  proc_table_remove(proc);
+
   proc_shm_detach_all(proc);
   proc_release_user_memory(proc);
   proc_file_table_cleanup(proc);
@@ -393,6 +427,8 @@ static void scheduler_cleanup_process(proc_info_p proc) {
   if(proc == NULL || proc == &kernel_process_info) {
     return;
   }
+
+  proc_table_remove(proc);
 
   proc_shm_detach_all(proc);
   if(proc->stack_pointer) {
@@ -617,6 +653,7 @@ void proc_create(proc_info_p proc, const char* name, void (*entrypoint)(void *),
   proc->children_count = 0;
   proc->parent = current;
   proc->pid = last_pid++;
+  proc_table_insert(proc);
   proc_file_table_init(proc);
   if(current != NULL) {
     proc_file_table_clone(proc, current);
@@ -1146,6 +1183,7 @@ proc_info_p proc_fork(proc_info_p parent, const syscall_frame_t* frame, int* err
 
   child->parent = parent;
   child->pid = last_pid++;
+  proc_table_insert(child);
   strncpy(child->name, parent->name, sizeof(child->name) - 1);
   child->name[sizeof(child->name) - 1] = '\0';
   child->user_mode = parent->user_mode;

--- a/src/kernel/proc/proc.c
+++ b/src/kernel/proc/proc.c
@@ -4,6 +4,7 @@
 #include <kernel/kernel.h>
 #include <kernel/pmm.h>
 #include <kernel/proc.h>
+#include <kernel/context_switch.h>
 #include <kernel/serial.h>
 #include <kernel/syscall_entry.h>
 #include <kernel/thread.h>
@@ -200,10 +201,7 @@ static void proc_free_resources(proc_info_p proc) {
     proc->address_space_root = 0;
   }
 
-  if(proc->cpu_state) {
-    kfree(proc->cpu_state);
-    proc->cpu_state = NULL;
-  }
+  proc->cpu_state = NULL;
 
   if(proc->stack_pointer) {
     kfree(proc->stack_pointer);
@@ -343,10 +341,7 @@ static void scheduler_cleanup_process(proc_info_p proc) {
     proc->address_space_root = 0;
   }
 
-  if(proc->cpu_state) {
-    kfree(proc->cpu_state);
-    proc->cpu_state = NULL;
-  }
+  proc->cpu_state = NULL;
 
   kfree(proc);
 }
@@ -359,12 +354,11 @@ void proc_debug(cpu_state_p state) {
   serial_printf("proc_debug: rdx: %lx r8:  %lx r9:  %lx r10: %lx\n", state->rdx, state->r8, state->r9, state->r10);
 }
 
-void proc_switch(void* arg) {
+cpu_state_p proc_switch(cpu_state_p frame) {
   if(current == NULL) {
     current = &kernel_process_info;
   }
 
-  cpu_state_p frame = (cpu_state_p)arg;
   uint64_t now = scheduler_now_us();
 
   if(last_exec == 0) {
@@ -386,6 +380,7 @@ void proc_switch(void* arg) {
 
   if(current && current->cpu_state) {
     memcpy(current->cpu_state, frame, sizeof(cpu_state_t));
+    current->kernel_rsp = (uint64_t)frame;
   }
 
   scheduler_wake_sleepers(now);
@@ -411,7 +406,7 @@ void proc_switch(void* arg) {
   if(!forced && current != NULL && current->state == PROC_STATE_RUNNING) {
     if(current->time_slice_remaining_us > 0 && highest_ready <= current->priority) {
       current->last_dispatch_us = now;
-      return;
+      return frame;
     }
   }
 
@@ -495,18 +490,20 @@ void proc_switch(void* arg) {
   serial_printf("proc_switch: restore pid=%u cpu_state->rax=%lx\n",
                 current->pid,
                 current->cpu_state->rax);
-  serial_printf("proc_switch: copy cpu_state->rax=%lx into frame %p\n",
-                current->cpu_state->rax,
-                (void*)frame);
-  if(current->cpu_state != frame) {
-    memcpy(frame, current->cpu_state, sizeof(cpu_state_t));
-  }
+  serial_printf("proc_switch: resume frame=%p\n", (void*)current->cpu_state);
 
   uint64_t kernel_stack = proc_kernel_stack_top(current);
   if(kernel_stack != 0) {
     tss_update_kernel_stack(kernel_stack);
     syscall_set_kernel_stack(kernel_stack);
   }
+
+  cpu_state_p next_frame = current->cpu_state;
+  uint64_t next_rsp = current->kernel_rsp ? current->kernel_rsp : (uint64_t)next_frame;
+  uint64_t dummy_prev = (uint64_t)frame;
+  uint64_t* prev_slot = previous ? &previous->kernel_rsp : &dummy_prev;
+  context_switch(prev_slot, next_rsp);
+  return next_frame;
 }
 
 void proc_create(proc_info_p proc, const char* name, void (*entrypoint)(void *), void* arg) {
@@ -563,20 +560,22 @@ void proc_create(proc_info_p proc, const char* name, void (*entrypoint)(void *),
   proc->waitpid_target = -1;
   proc->waitpid_waiting = false;
 
-  proc->cpu_state = kmalloc(sizeof(cpu_state_t));
-  if(proc->cpu_state == NULL) {
-    serial_printf("proc_create: Failed to allocate cpu state for process %s\n", name);
-    halt();
-  }
+  proc->cpu_state = (cpu_state_t*)((uint8_t*)proc->stack_base + PROC_STACK_SIZE - sizeof(cpu_state_t));
   memset(proc->cpu_state, 0, sizeof(cpu_state_t));
+  proc->kernel_rsp = (uint64_t)proc->cpu_state;
   proc->cpu_state->rip = (uint64_t)entrypoint;
   proc->cpu_state->rdi = (uint64_t)arg;
   proc->cpu_state->rsp = (uint64_t)proc->stack_base + PROC_STACK_SIZE;
   proc->cpu_state->rbp = proc->cpu_state->rsp;
   proc->cpu_state->rflags = 0x246;
-  serial_printf("proc_create: cs: %lx ss: %lx\n", current->cpu_state->cs, current->cpu_state->ss);
-  proc->cpu_state->cs = KERNEL_CODE_SEGMENT;
-  proc->cpu_state->ss = KERNEL_DATA_SEGMENT;
+  uint16_t cs = KERNEL_CODE_SEGMENT;
+  uint16_t ss = KERNEL_DATA_SEGMENT;
+  if(current != NULL && current->cpu_state != NULL) {
+    cs = current->cpu_state->cs;
+    ss = current->cpu_state->ss;
+  }
+  proc->cpu_state->cs = cs;
+  proc->cpu_state->ss = ss;
   proc->address_space_root = pmm_get_kernel_cr3();
   proc->user_segment_count = 0;
   proc->shm_attachment_count = 0;
@@ -1075,13 +1074,9 @@ proc_info_p proc_fork(proc_info_p parent, const syscall_frame_t* frame, int* err
   memset(child->stack_base, 0, PROC_STACK_SIZE);
   serial_printf("proc_fork: stack allocated aligned=%p\n", child->stack_base);
 
-  child->cpu_state = kmalloc(sizeof(cpu_state_t));
-  if(child->cpu_state == NULL) {
-    serial_printf("proc_fork: cpu_state allocation failed\n");
-    proc_free_resources(child);
-    return NULL;
-  }
+  child->cpu_state = (cpu_state_t*)((uint8_t*)child->stack_base + PROC_STACK_SIZE - sizeof(cpu_state_t));
   memset(child->cpu_state, 0, sizeof(cpu_state_t));
+  child->kernel_rsp = (uint64_t)child->cpu_state;
   serial_printf("proc_fork: cpu_state allocated\n");
 
   phys_addr_t new_root = pmm_clone_kernel_address_space();

--- a/src/kernel/syscall/syscall.c
+++ b/src/kernel/syscall/syscall.c
@@ -310,7 +310,7 @@ static uint64_t syscall_finalize(syscall_frame_t* frame) {
       proc_signal_handle_pending(current, (cpu_state_t*)frame);
   if(delivery == PROC_SIGNAL_DELIVERY_TERMINATED ||
      delivery == PROC_SIGNAL_DELIVERY_STOPPED) {
-    proc_switch((void*)frame);
+    frame = proc_switch(frame);
   }
 
   serial_printf("syscall_finalize: exit pid=%u rax=%lx delivery=%d\n",
@@ -943,10 +943,9 @@ static uint64_t syscall_waitpid_handler(syscall_frame_t* frame) {
 
     caller->state = PROC_STATE_WAITING;
     proc_request_block();
-    proc_switch((void*)frame);
-    if(current != caller) {
-      return frame->rax;
-    }
+    do {
+      frame = proc_switch(frame);
+    } while(current != caller);
     caller->state = PROC_STATE_RUNNING;
     continue;
   }
@@ -1330,16 +1329,22 @@ static uint64_t syscall_proc_kill_handler(syscall_frame_t* frame) {
 }
 
 static uint64_t syscall_yield_handler(syscall_frame_t* frame) {
+  proc_info_p caller = current;
   proc_request_yield();
-  proc_switch((void*)frame);
+  do {
+    frame = proc_switch(frame);
+  } while(current != caller);
   frame->rax = 0;
   return 0;
 }
 
 static uint64_t syscall_sleep_handler(syscall_frame_t* frame) {
   uint64_t usec = frame->rdi;
+  proc_info_p caller = current;
   proc_request_sleep(usec);
-  proc_switch((void*)frame);
+  do {
+    frame = proc_switch(frame);
+  } while(current != caller);
   frame->rax = 0;
   return 0;
 }
@@ -1347,8 +1352,12 @@ static uint64_t syscall_sleep_handler(syscall_frame_t* frame) {
 static uint64_t syscall_exit_handler(syscall_frame_t* frame) {
   int status = (int)frame->rdi;
   proc_exit(status);
-  proc_switch((void*)frame);
-  return frame->rax;
+  while(true) {
+    frame = proc_switch(frame);
+    if(current != NULL) {
+      return frame->rax;
+    }
+  }
 }
 
 static uint64_t syscall_fcntl_handler(syscall_frame_t* frame) {

--- a/src/kernel/syscall/syscall.c
+++ b/src/kernel/syscall/syscall.c
@@ -41,6 +41,10 @@ void syscall_trace_return(uint64_t value) {
                 current ? current->pid : 0u,
                 (unsigned long)value);
 }
+#else
+void syscall_trace_return(uint64_t value) {
+  (void)value;
+}
 #endif
 
 #if SYSCALL_TRACE_ENABLED
@@ -1190,7 +1194,8 @@ static uint64_t syscall_proc_list_handler(syscall_frame_t* frame) {
       continue;
     }
 
-    if(proc->state == PROC_STATE_TERMINATED) {
+    if(proc->state == PROC_STATE_TERMINATED ||
+       proc->state == PROC_STATE_ZOMBIE) {
       continue;
     }
 

--- a/src/kernel/syscall/syscall.c
+++ b/src/kernel/syscall/syscall.c
@@ -298,6 +298,16 @@ static uint64_t syscall_finalize(syscall_frame_t* frame) {
                 current ? current->pid : 0u,
                 (unsigned long)frame->rax);
 
+  if(current != NULL && current->pid == 2 && frame != NULL) {
+    serial_printf("syscall_finalize frame pid=2 rip=%lx rsp=%lx rdi=%lx rsi=%lx rdx=%lx rcx=%lx\n",
+                  (unsigned long)frame->rip,
+                  (unsigned long)frame->rsp,
+                  (unsigned long)frame->rdi,
+                  (unsigned long)frame->rsi,
+                  (unsigned long)frame->rdx,
+                  (unsigned long)frame->rcx);
+  }
+
 #ifndef MENIOS_HOST_TEST
   syscall_last_return_value = frame->rax;
 #endif
@@ -310,18 +320,31 @@ static uint64_t syscall_finalize(syscall_frame_t* frame) {
       proc_signal_handle_pending(current, (cpu_state_t*)frame);
   if(delivery == PROC_SIGNAL_DELIVERY_TERMINATED ||
      delivery == PROC_SIGNAL_DELIVERY_STOPPED) {
-    frame = proc_switch(frame);
+    frame = (syscall_frame_t*)proc_switch((cpu_state_p)frame);
   }
 
   serial_printf("syscall_finalize: exit pid=%u rax=%lx delivery=%d\n",
                 current ? current->pid : 0u,
                 (unsigned long)frame->rax,
                 (int)delivery);
+  if(current != NULL && current->pid == 2 && frame != NULL) {
+    serial_printf("syscall_finalize exit frame pid=2 rip=%lx rsp=%lx rdi=%lx rsi=%lx rdx=%lx rcx=%lx\n",
+                  (unsigned long)frame->rip,
+                  (unsigned long)frame->rsp,
+                  (unsigned long)frame->rdi,
+                  (unsigned long)frame->rsi,
+                  (unsigned long)frame->rdx,
+                  (unsigned long)frame->rcx);
+  }
 #ifndef MENIOS_HOST_TEST
   serial_printf("syscall_finalize: stored=%lx slot=%lx\n",
                 (unsigned long)syscall_last_return_value,
                 (unsigned long)syscall_last_return_slot_value);
 #endif
+  if(current != NULL) {
+    current->syscall_gs_active = false;
+    current->syscall_gs_needs_restore = false;
+  }
   return frame->rax;
 }
 
@@ -470,6 +493,11 @@ void syscall_init(void) {
 
 uint64_t syscall_dispatch(syscall_frame_t* frame) {
   uint64_t number = frame->rax;
+
+  if(current != NULL) {
+    current->syscall_gs_active = true;
+    current->syscall_gs_needs_restore = false;
+  }
 
   serial_printf("syscall_dispatch: pid=%u number=%lu rip=%lx cs=%lx rsp=%lx\n",
                 current ? current->pid : 0u,
@@ -944,7 +972,7 @@ static uint64_t syscall_waitpid_handler(syscall_frame_t* frame) {
     caller->state = PROC_STATE_WAITING;
     proc_request_block();
     do {
-      frame = proc_switch(frame);
+      frame = (syscall_frame_t*)proc_switch((cpu_state_p)frame);
     } while(current != caller);
     caller->state = PROC_STATE_RUNNING;
     continue;
@@ -1332,7 +1360,7 @@ static uint64_t syscall_yield_handler(syscall_frame_t* frame) {
   proc_info_p caller = current;
   proc_request_yield();
   do {
-    frame = proc_switch(frame);
+    frame = (syscall_frame_t*)proc_switch((cpu_state_p)frame);
   } while(current != caller);
   frame->rax = 0;
   return 0;
@@ -1343,7 +1371,7 @@ static uint64_t syscall_sleep_handler(syscall_frame_t* frame) {
   proc_info_p caller = current;
   proc_request_sleep(usec);
   do {
-    frame = proc_switch(frame);
+    frame = (syscall_frame_t*)proc_switch((cpu_state_p)frame);
   } while(current != caller);
   frame->rax = 0;
   return 0;
@@ -1352,12 +1380,11 @@ static uint64_t syscall_sleep_handler(syscall_frame_t* frame) {
 static uint64_t syscall_exit_handler(syscall_frame_t* frame) {
   int status = (int)frame->rdi;
   proc_exit(status);
-  while(true) {
-    frame = proc_switch(frame);
-    if(current != NULL) {
-      return frame->rax;
-    }
+  syscall_frame_t* resumed = (syscall_frame_t*)proc_switch((cpu_state_p)frame);
+  if(resumed != NULL && resumed != frame) {
+    memcpy(frame, resumed, sizeof(syscall_frame_t));
   }
+  return frame->rax;
 }
 
 static uint64_t syscall_fcntl_handler(syscall_frame_t* frame) {

--- a/src/kernel/syscall/syscall.c
+++ b/src/kernel/syscall/syscall.c
@@ -21,18 +21,39 @@
 #include <stdint.h>
 
 #ifndef MENIOS_HOST_TEST
-#define ENABLE_SYSCALL_TRACE 1
+
+#ifndef CONFIG_DEBUG_SYSCALL
+#define CONFIG_DEBUG_SYSCALL 0
+#endif
+
+#if CONFIG_DEBUG_SYSCALL
+#define SYSCALL_TRACE_ENABLED 1
+#else
+#define SYSCALL_TRACE_ENABLED 0
+#endif
 
 extern uint64_t syscall_last_return_value;
 extern uint64_t syscall_last_return_slot_value;
 
-#ifdef ENABLE_SYSCALL_TRACE
+#if SYSCALL_TRACE_ENABLED
 void syscall_trace_return(uint64_t value) {
   serial_printf("[sysret-trace] pid=%u rax=%lx\n",
                 current ? current->pid : 0u,
                 (unsigned long)value);
 }
 #endif
+
+#if SYSCALL_TRACE_ENABLED
+#define SYSCALL_TRACE(...) serial_printf(__VA_ARGS__)
+#else
+#define SYSCALL_TRACE(...) ((void)0)
+#endif
+
+#else
+
+#define SYSCALL_TRACE_ENABLED 0
+#define SYSCALL_TRACE(...) ((void)0)
+
 #endif
 
 #define SYSCALL_MAX 256
@@ -294,12 +315,12 @@ static uint64_t syscall_finalize(syscall_frame_t* frame) {
     return frame->rax;
   }
 
-  serial_printf("syscall_finalize: entry pid=%u rax=%lx\n",
+  SYSCALL_TRACE("syscall_finalize: entry pid=%u rax=%lx\n",
                 current ? current->pid : 0u,
                 (unsigned long)frame->rax);
 
   if(current != NULL && current->pid == 2 && frame != NULL) {
-    serial_printf("syscall_finalize frame pid=2 rip=%lx rsp=%lx rdi=%lx rsi=%lx rdx=%lx rcx=%lx\n",
+    SYSCALL_TRACE("syscall_finalize frame pid=2 rip=%lx rsp=%lx rdi=%lx rsi=%lx rdx=%lx rcx=%lx\n",
                   (unsigned long)frame->rip,
                   (unsigned long)frame->rsp,
                   (unsigned long)frame->rdi,
@@ -323,12 +344,12 @@ static uint64_t syscall_finalize(syscall_frame_t* frame) {
     frame = (syscall_frame_t*)proc_switch((cpu_state_p)frame);
   }
 
-  serial_printf("syscall_finalize: exit pid=%u rax=%lx delivery=%d\n",
+  SYSCALL_TRACE("syscall_finalize: exit pid=%u rax=%lx delivery=%d\n",
                 current ? current->pid : 0u,
                 (unsigned long)frame->rax,
                 (int)delivery);
   if(current != NULL && current->pid == 2 && frame != NULL) {
-    serial_printf("syscall_finalize exit frame pid=2 rip=%lx rsp=%lx rdi=%lx rsi=%lx rdx=%lx rcx=%lx\n",
+    SYSCALL_TRACE("syscall_finalize exit frame pid=2 rip=%lx rsp=%lx rdi=%lx rsi=%lx rdx=%lx rcx=%lx\n",
                   (unsigned long)frame->rip,
                   (unsigned long)frame->rsp,
                   (unsigned long)frame->rdi,
@@ -337,7 +358,7 @@ static uint64_t syscall_finalize(syscall_frame_t* frame) {
                   (unsigned long)frame->rcx);
   }
 #ifndef MENIOS_HOST_TEST
-  serial_printf("syscall_finalize: stored=%lx slot=%lx\n",
+  SYSCALL_TRACE("syscall_finalize: stored=%lx slot=%lx\n",
                 (unsigned long)syscall_last_return_value,
                 (unsigned long)syscall_last_return_slot_value);
 #endif
@@ -499,7 +520,7 @@ uint64_t syscall_dispatch(syscall_frame_t* frame) {
     current->syscall_gs_needs_restore = false;
   }
 
-  serial_printf("syscall_dispatch: pid=%u number=%lu rip=%lx cs=%lx rsp=%lx\n",
+  SYSCALL_TRACE("syscall_dispatch: pid=%u number=%lu rip=%lx cs=%lx rsp=%lx\n",
                 current ? current->pid : 0u,
                 number,
                 (unsigned long)frame->rip,
@@ -511,7 +532,7 @@ uint64_t syscall_dispatch(syscall_frame_t* frame) {
     if(handler) {
       uint64_t result = handler(frame);
       frame->rax = result;
-      serial_printf("syscall_dispatch: post-handler rip=%lx cs=%lx rsp=%lx rax=%lx\n",
+      SYSCALL_TRACE("syscall_dispatch: post-handler rip=%lx cs=%lx rsp=%lx rax=%lx\n",
                     (unsigned long)frame->rip,
                     (unsigned long)frame->cs,
                     (unsigned long)frame->rsp,
@@ -521,7 +542,7 @@ uint64_t syscall_dispatch(syscall_frame_t* frame) {
   }
 
   frame->rax = (uint64_t)(-ENOSYS);
-  serial_printf("syscall_dispatch: unknown syscall rip=%lx\n",
+  SYSCALL_TRACE("syscall_dispatch: unknown syscall rip=%lx\n",
                 (unsigned long)frame->rip);
   return syscall_finalize(frame);
 }
@@ -577,7 +598,7 @@ static uint64_t syscall_write_handler(syscall_frame_t* frame) {
   } else {
     sample[0] = '\0';
   }
-  serial_printf("write: pid=%u fd=%d len=%lu sample='%s'\n",
+  SYSCALL_TRACE("write: pid=%u fd=%d len=%lu sample='%s'\n",
                 current->pid,
                 fd,
                 (unsigned long)length,
@@ -642,7 +663,7 @@ static uint64_t syscall_open_handler(syscall_frame_t* frame) {
   file_t* file = NULL;
   int rc = vfs_open(absolute, flags, &file);
   if(rc < 0) {
-    serial_printf("syscall_open: pid=%u path=%s flags=0x%x rc=%d\n",
+    SYSCALL_TRACE("syscall_open: pid=%u path=%s flags=0x%x rc=%d\n",
                   current->pid,
                   absolute,
                   flags,
@@ -790,10 +811,10 @@ static uint64_t syscall_dup2_handler(syscall_frame_t* frame) {
 
 static uint64_t syscall_fork_handler(syscall_frame_t* frame) {
   int err = 0;
-  serial_printf("syscall_fork: pid=%u entering\n", current ? current->pid : 0);
+  SYSCALL_TRACE("syscall_fork: pid=%u entering\n", current ? current->pid : 0);
   proc_info_p child = proc_fork(current, frame, &err);
   if(child == NULL) {
-    serial_printf("syscall_fork: failure err=%d\n", err);
+    SYSCALL_TRACE("syscall_fork: failure err=%d\n", err);
     if(err == 0) {
       err = -ENOMEM;
     }
@@ -802,7 +823,7 @@ static uint64_t syscall_fork_handler(syscall_frame_t* frame) {
   }
 
   frame->rax = (uint64_t)child->pid;
-  serial_printf("syscall_fork: returning child pid=%lu\n", frame->rax);
+  SYSCALL_TRACE("syscall_fork: returning child pid=%lu\n", frame->rax);
   return frame->rax;
 }
 
@@ -836,8 +857,8 @@ static uint64_t syscall_execve_handler(syscall_frame_t* frame) {
     return frame->rax;
   }
 
-  serial_printf("execve: pid=%u path=%s\n", current ? current->pid : 0, absolute);
-  serial_printf("execve: frame->rsi=%p frame->rdx=%p\n", (void*)frame->rsi, (void*)frame->rdx);
+  SYSCALL_TRACE("execve: pid=%u path=%s\n", current ? current->pid : 0, absolute);
+  SYSCALL_TRACE("execve: frame->rsi=%p frame->rdx=%p\n", (void*)frame->rsi, (void*)frame->rdx);
 
   char** argv = NULL;
   size_t argc = 0;
@@ -847,7 +868,7 @@ static uint64_t syscall_execve_handler(syscall_frame_t* frame) {
                         &argv,
                         &argc,
                         &vector_err)) {
-    serial_printf("execve: clone_user_vector argv failed err=%d\n", vector_err);
+    SYSCALL_TRACE("execve: clone_user_vector argv failed err=%d\n", vector_err);
     free_string_vector(argv, argc);
     if(current) {
       current->err_no = vector_err ? -vector_err : EFAULT;
@@ -863,7 +884,7 @@ static uint64_t syscall_execve_handler(syscall_frame_t* frame) {
                         &envp,
                         &envc,
                         &vector_err)) {
-    serial_printf("execve: clone_user_vector envp failed err=%d\n", vector_err);
+    SYSCALL_TRACE("execve: clone_user_vector envp failed err=%d\n", vector_err);
     free_string_vector(argv, argc);
     if(current) {
       current->err_no = vector_err ? -vector_err : EFAULT;
@@ -871,14 +892,14 @@ static uint64_t syscall_execve_handler(syscall_frame_t* frame) {
     frame->rax = (uint64_t)(vector_err ? vector_err : -EFAULT);
     return frame->rax;
   }
-  serial_printf("execve: argc=%lu envc=%lu\n",
+  SYSCALL_TRACE("execve: argc=%lu envc=%lu\n",
                 (unsigned long)argc,
                 (unsigned long)envc);
 
   void* image = NULL;
   size_t size = 0;
   if(!vfs_read_all(absolute, &image, &size) || image == NULL || size == 0) {
-    serial_printf("execve: vfs_read_all failed size=%lu\n", (unsigned long)size);
+    SYSCALL_TRACE("execve: vfs_read_all failed size=%lu\n", (unsigned long)size);
     if(image != NULL) {
       kfree(image);
     }
@@ -910,7 +931,7 @@ static uint64_t syscall_execve_handler(syscall_frame_t* frame) {
   };
 
   int err = proc_exec_image(current, image, size, frame, &exec_args);
-  serial_printf("execve: proc_exec_image err=%d\n", err);
+  SYSCALL_TRACE("execve: proc_exec_image err=%d\n", err);
   kfree(image);
   free_string_vector(argv, argc);
   free_string_vector(envp, envc);
@@ -925,7 +946,7 @@ static uint64_t syscall_waitpid_handler(syscall_frame_t* frame) {
     return frame->rax;
   }
 
-  serial_printf("waitpid: caller pid=%u pid=%d\n", caller->pid, (int)frame->rdi);
+  SYSCALL_TRACE("waitpid: caller pid=%u pid=%d\n", caller->pid, (int)frame->rdi);
 
   int pid = (int)frame->rdi;
   int* status_ptr = (int*)frame->rsi;
@@ -935,7 +956,7 @@ static uint64_t syscall_waitpid_handler(syscall_frame_t* frame) {
   for(;;) {
     int status = 0;
     int result = proc_waitpid(caller, pid, options, &status);
-    serial_printf("waitpid: loop result=%d status=%d\n", result, status);
+    SYSCALL_TRACE("waitpid: loop result=%d status=%d\n", result, status);
 
     if(result > 0) {
       if(status_ptr != NULL) {

--- a/src/usermode/init.c
+++ b/src/usermode/init.c
@@ -235,6 +235,7 @@ void _start(void) {
 
     write_str(STDOUT_FILENO, "[init] shell exited, restarting\n");
     write_log("[init] restarting shell\n");
+    sleep_us(250000);
   }
 #endif
 }

--- a/test/stubs.c
+++ b/test/stubs.c
@@ -76,6 +76,8 @@ void proc_request_sleep(uint64_t duration_us) {
   (void)duration_us;
 }
 
+void proc_request_block(void) {}
+
 void proc_mark_ready(proc_info_p proc) {
   if(proc) {
     proc->state = PROC_STATE_READY;
@@ -110,8 +112,8 @@ void proc_mark_continued(proc_info_p proc) {
   }
 }
 
-void proc_switch(void* frame) {
-  (void)frame;
+cpu_state_p proc_switch(cpu_state_p state) {
+  return state;
 }
 
 void memzero(void* s, uint64_t n) {

--- a/test/test_mosh_line.c
+++ b/test/test_mosh_line.c
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -273,6 +274,22 @@ void test_default_environment_provides_path(void) {
   TEST_ASSERT_EQUAL_STRING("/bin", env_get("PATH"));
 }
 
+static void test_variable_expansion_long_braced_literal(void) {
+  const char* input = "echo ${ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789} tail";
+  char output[128];
+  bool ok = shell_expand_variables(input, output, sizeof(output));
+  TEST_ASSERT_TRUE(ok);
+  TEST_ASSERT_EQUAL_STRING(input, output);
+}
+
+static void test_variable_expansion_long_unbraced_literal(void) {
+  const char* input = "echo $ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 tail";
+  char output[128];
+  bool ok = shell_expand_variables(input, output, sizeof(output));
+  TEST_ASSERT_TRUE(ok);
+  TEST_ASSERT_EQUAL_STRING(input, output);
+}
+
 int main(void) {
   UNITY_BEGIN();
 
@@ -304,6 +321,8 @@ int main(void) {
   RUN_TEST(test_reverse_search_no_match_beeps);
   RUN_TEST(test_reverse_search_cancel_restores_line);
   RUN_TEST(test_ctrl_c_clears_line);
+  RUN_TEST(test_variable_expansion_long_braced_literal);
+  RUN_TEST(test_variable_expansion_long_unbraced_literal);
 
   return UNITY_END();
 }


### PR DESCRIPTION
# Overview

- Refactored scheduler context management so every process now keeps its own switch frame.context_switch saves/restores through proc_switch, and sys_exit copies the resumed frame back into the caller before returning. mosh no longer crashes or loops when supervised.

- Introduced debug guards (CONFIG_DEBUG_SYSCALL, CONFIG_DEBUG_SCHEDULER) so we can re-enable tracing without drowning the serial log; default builds run quiet while failure paths still print diagnostics.

- Cleaned up fork/exec instrumentation and logging, improved wait/sleep handling, and kept syscall_finalize/waitpid stable after the refactor.

##  Testing

- `make test DOCKER_IMAGE=menios:trunk` (host suite)
- Manual QEMU smoke: boot, `ls /`, `cat limine.conf`, `ps`, run `/bin/malloc_stress --target-mb=1 --progress=1000`, confirm prompt returns after child exit